### PR TITLE
Improve overview page

### DIFF
--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -1,3 +1,24 @@
+# Introduction to μNet
+
+> **Audience:** Network engineers evaluating or adopting μNet.
+> **Objective:** Provide a quick overview of what the project offers and how the rest of the documentation is organized.
+
+μNet is an open‑source network configuration system written in Rust. It stores your **desired configuration** in a database, polls devices to collect **actual state**, and highlights drift through a powerful policy engine. Configurations are rendered from reusable templates, giving you consistent, vendor‑specific output while keeping everything under version control for easy auditing and rollback.
+
+Some highlights:
+
+- **Single‑binary** server and CLI – deploy one Rust executable for both API and command line interactions.
+- **SQLite** backend managed via SeaORM for reliable ACID transactions.
+- **Custom policy DSL** to enforce standards and detect configuration drift.
+- **MiniJinja** templates for fast, deterministic config generation.
+- **Hierarchical config diffing** provided by the standalone `config-slicer` crate.
+- **Prometheus** metrics and structured logging for observability.
+- **Example fixtures** so you can try μNet without writing your own dataset.
+
+You can spin up a demo in minutes: clone the repo, run `cargo run -p unet-server`, then visit [`http://localhost:3000`](http://localhost:3000) for the API and documentation. The CLI (`unet`) lets you add nodes, run policy checks, and preview rendered configs.
+
+The rest of this documentation is organized as follows:
+
 | Order  | File name                      | Purpose (headline)                                                                         |
 | ------ | ------------------------------ | ------------------------------------------------------------------------------------------ |
 | **1**  | **01\_architecture.md**        | System overview, flow diagram, component responsibilities, and tech-stack rationale.       |


### PR DESCRIPTION
## Summary
- enhance `docs/src/overview.md` with a detailed introduction and quickstart instructions

## Testing
- `cargo fmt --all`
- `timeout 60 cargo clippy --all-targets --all-features -q` *(fails: warnings shown, command timed out)*
- `timeout 60 cargo test --workspace --quiet` *(command timed out with no output)*

------
https://chatgpt.com/codex/tasks/task_e_6866108eefa0832aa53015238d6e6e4f