### PR TITLE
Add mise preflight workflow

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,18 @@
+name: Preflight
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          experimental: true
+      - run: mise run lint
+      - run: mise run test
+      - run: mise run check-large-files
+

--- a/mise.toml
+++ b/mise.toml
@@ -17,5 +17,5 @@ run = [
 [tasks.check-large-files]
 description = "Find files exceeding size guidelines (>400 lines)"
 run = [
-  "find /home/bc/code/unet/crates -name '*.rs' -exec wc -l {} + | awk '$1 > 400 {print $0}' | sort -nr",
+  "find ./crates -name '*.rs' -exec wc -l {} + | awk '$1 > 400 {print $0}' | sort -nr",
 ]


### PR DESCRIPTION
## Summary
- add CI workflow that runs lint, test, and large-file check using `jdx/mise-action`
- run on pull requests to `master`
- enable experimental mode for `mise-action`
- fix `check-large-files` task path

## Testing
- `mise run lint`
- `mise run test` *(fails: 4 tests fail)*
- `mise run check-large-files`


------
https://chatgpt.com/codex/tasks/task_e_687d263623a0832aa2daa4b785cd7aff