### PR TITLE
ci: cache build artifacts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,12 +19,10 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           experimental: true
+          cache: true
       - run: mise install
-      - name: Ensure Rust components are available
-        run: |
-          rustup component add rustfmt
-          rustup component add clippy
-          rustup component add llvm-tools-preview
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
       - run: mise run lint
       - run: mise run test
       - name: Generate coverage report and enforce threshold
@@ -47,6 +45,7 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           experimental: true
+          cache: true
 
       - run: mise install
 

--- a/crates/unet-core/src/logging/comprehensive_tests.rs
+++ b/crates/unet-core/src/logging/comprehensive_tests.rs
@@ -86,19 +86,19 @@ fn test_init_tracing_with_file_json_format() {
 }
 
 #[test]
-fn test_init_tracing_with_file_permission_error() {
+fn test_init_tracing_fails_when_directory_cannot_be_created() {
     let config = LoggingConfig {
         level: "info".to_string(),
         format: "pretty".to_string(),
-        file: Some("/root/protected/cannot_create.log".to_string()),
+        file: Some("/proc/protected/cannot_create.log".to_string()),
     };
 
-    // Test validation passes but directory creation would fail
+    // Test validation passes but directory creation will fail on read-only paths
     assert!(validate_log_level(&config.level).is_ok());
     assert!(validate_log_format(&config.format).is_ok());
 
-    // Test that attempting to create the directory fails due to permissions
-    let result = std::fs::create_dir_all("/root/protected");
+    // Attempt to create a directory in `/proc`, which is read-only even for root
+    let result = std::fs::create_dir_all("/proc/protected");
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
## Summary
- cache Rust build artifacts in CI to reduce setup time
- enable caching for mise tooling in security audit
- fix logging test to handle runs as root

## Testing
- `mise run lint` *(fails: clippy --fix attempted changes that caused borrow checker errors)*
- `cargo clippy --workspace`
- `cargo nextest run -p unet-core logging::comprehensive_tests::test_init_tracing_fails_when_directory_cannot_be_created`
- `mise run check-large-files`


------
https://chatgpt.com/codex/tasks/task_e_688f93c165a0832a881290797ae6dcb0