### PR TITLE
fix(snmp): require explicit SNMP credentials at startup

### DIFF
--- a/crates/unet-core/src/config/core.rs
+++ b/crates/unet-core/src/config/core.rs
@@ -41,8 +41,7 @@ impl Config {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file path contains invalid UTF-8, the file cannot be read,
-    /// or the configuration cannot be parsed as valid TOML.
+    /// Returns an error if the file path contains invalid UTF-8, the file cannot be read, or the configuration cannot be parsed as valid TOML.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path_str = path.as_ref().to_str().ok_or_else(|| {
             Error::config(format!(
@@ -81,8 +80,7 @@ impl Config {
     ///
     /// # Errors
     ///
-    /// Returns an error if configuration overrides cannot be set, the configuration cannot be built,
-    /// or the resulting configuration cannot be deserialized.
+    /// Returns an error if configuration overrides cannot be set, the configuration cannot be built, or the resulting configuration cannot be deserialized.
     pub fn from_env_with_source<F>(env_source: F) -> Result<Self>
     where
         F: Fn(&str) -> std::result::Result<String, std::env::VarError>,
@@ -110,8 +108,7 @@ impl Config {
     ///
     /// # Errors
     ///
-    /// Returns an error if the configuration cannot be serialized to TOML
-    /// or if the file cannot be written to the specified path.
+    /// Returns an error if the configuration cannot be serialized to TOML or if the file cannot be written to the specified path.
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let toml_content = toml::to_string_pretty(self)
             .map_err(|e| Error::config(format!("Failed to serialize config: {e}")))?;
@@ -130,10 +127,14 @@ impl Config {
     ///
     /// # Errors
     ///
-    /// Returns an error if any configuration values are invalid, such as empty required fields,
-    /// zero values where positive values are required, or invalid network addresses.
+    /// Returns an error if any configuration values are invalid, such as empty required fields, zero values where positive values are required, or invalid network addresses.
     pub fn validate(&self) -> Result<()> {
         self.validate_database()?;
+        if self.snmp.community.trim().is_empty() {
+            return Err(Error::config(
+                "SNMP community must be configured explicitly",
+            ));
+        }
         self.validate_server()?;
         self.validate_git()?;
         self.validate_auth()?;
@@ -230,7 +231,7 @@ impl Default for Config {
                 file: None,
             },
             snmp: SnmpConfig {
-                community: defaults::snmp::DEFAULT_SNMP_COMMUNITY.to_string(),
+                community: String::new(),
                 timeout: defaults::snmp::DEFAULT_SNMP_TIMEOUT_SECONDS,
                 retries: defaults::snmp::DEFAULT_SNMP_RETRIES,
             },

--- a/crates/unet-core/src/config/core_tests/creation_tests.rs
+++ b/crates/unet-core/src/config/core_tests/creation_tests.rs
@@ -35,10 +35,6 @@ fn test_config_default() {
     assert!(config.logging.file.is_none());
 
     assert_eq!(
-        config.snmp.community,
-        defaults::snmp::DEFAULT_SNMP_COMMUNITY
-    );
-    assert_eq!(
         config.snmp.timeout,
         defaults::snmp::DEFAULT_SNMP_TIMEOUT_SECONDS
     );
@@ -61,4 +57,10 @@ fn test_config_default() {
 
     assert!(!config.auth.enabled);
     assert!(config.auth.token.is_none());
+}
+
+#[test]
+fn test_config_default_snmp_community_is_empty() {
+    let config = Config::default();
+    assert!(config.snmp.community.is_empty());
 }

--- a/crates/unet-core/src/config/core_tests/file_tests.rs
+++ b/crates/unet-core/src/config/core_tests/file_tests.rs
@@ -82,7 +82,7 @@ port = 8080
 max_request_size = 1048576
 
 [snmp]
-community = "public"
+community = "test-community"
 timeout = 5
 retries = 3
 

--- a/crates/unet-core/src/config/core_tests/validation_tests.rs
+++ b/crates/unet-core/src/config/core_tests/validation_tests.rs
@@ -2,6 +2,12 @@
 
 use super::super::core::Config;
 
+fn config_with_explicit_snmp_community() -> Config {
+    let mut config = Config::default();
+    config.snmp.community = "test-community".to_string();
+    config
+}
+
 #[test]
 fn test_config_validate_default_config_requires_snmp_community() {
     let config = Config::default();
@@ -32,7 +38,7 @@ fn test_config_validate_empty_snmp_community() {
 
 #[test]
 fn test_config_validate_empty_database_url() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.database.url = String::new();
 
     let result = config.validate();
@@ -43,7 +49,7 @@ fn test_config_validate_empty_database_url() {
 
 #[test]
 fn test_config_validate_zero_database_max_connections() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.database.max_connections = Some(0);
 
     let result = config.validate();
@@ -58,7 +64,7 @@ fn test_config_validate_zero_database_max_connections() {
 
 #[test]
 fn test_config_validate_zero_database_timeout() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.database.timeout = Some(0);
 
     let result = config.validate();
@@ -73,7 +79,7 @@ fn test_config_validate_zero_database_timeout() {
 
 #[test]
 fn test_config_validate_empty_server_host() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.server.host = String::new();
 
     let result = config.validate();
@@ -84,7 +90,7 @@ fn test_config_validate_empty_server_host() {
 
 #[test]
 fn test_config_validate_zero_server_port() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.server.port = 0;
 
     let result = config.validate();
@@ -99,7 +105,7 @@ fn test_config_validate_zero_server_port() {
 
 #[test]
 fn test_config_validate_zero_max_request_size() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.server.max_request_size = 0;
 
     let result = config.validate();
@@ -114,7 +120,7 @@ fn test_config_validate_zero_max_request_size() {
 
 #[test]
 fn test_config_validate_invalid_server_address() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.server.host = "invalid host with spaces".to_string();
 
     let result = config.validate();
@@ -125,7 +131,7 @@ fn test_config_validate_invalid_server_address() {
 
 #[test]
 fn test_config_validate_empty_git_branch() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.git.branch = String::new();
 
     let result = config.validate();
@@ -136,7 +142,7 @@ fn test_config_validate_empty_git_branch() {
 
 #[test]
 fn test_config_validate_zero_git_sync_interval() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.git.sync_interval = 0;
 
     let result = config.validate();
@@ -151,7 +157,7 @@ fn test_config_validate_zero_git_sync_interval() {
 
 #[test]
 fn test_config_validate_auth_enabled_without_token() {
-    let mut config = Config::default();
+    let mut config = config_with_explicit_snmp_community();
     config.auth.enabled = true;
 
     let result = config.validate();

--- a/crates/unet-core/src/config/core_tests/validation_tests.rs
+++ b/crates/unet-core/src/config/core_tests/validation_tests.rs
@@ -3,9 +3,31 @@
 use super::super::core::Config;
 
 #[test]
-fn test_config_validate_valid_config() {
+fn test_config_validate_default_config_requires_snmp_community() {
     let config = Config::default();
-    assert!(config.validate().is_ok());
+    let result = config.validate();
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("SNMP community must be configured explicitly")
+    );
+}
+
+#[test]
+fn test_config_validate_empty_snmp_community() {
+    let mut config = Config::default();
+    config.snmp.community = String::new();
+
+    let result = config.validate();
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("SNMP community must be configured explicitly")
+    );
 }
 
 #[test]

--- a/crates/unet-core/src/config/defaults.rs
+++ b/crates/unet-core/src/config/defaults.rs
@@ -30,8 +30,6 @@ pub mod database {
 
 /// SNMP configuration constants
 pub mod snmp {
-    /// Default SNMP community string
-    pub const DEFAULT_SNMP_COMMUNITY: &str = "public";
     /// Default SNMP timeout in seconds
     pub const DEFAULT_SNMP_TIMEOUT_SECONDS: u64 = 5;
     /// Default SNMP retries

--- a/crates/unet-core/src/config/types.rs
+++ b/crates/unet-core/src/config/types.rs
@@ -27,7 +27,7 @@ pub struct LoggingConfig {
 /// SNMP configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnmpConfig {
-    /// Default SNMP community string
+    /// SNMP community string, configured explicitly for runtime use
     pub community: String,
     /// SNMP timeout in seconds
     pub timeout: u64,

--- a/crates/unet-core/src/snmp/client/client_operations_tests.rs
+++ b/crates/unet-core/src/snmp/client/client_operations_tests.rs
@@ -42,7 +42,7 @@ fn create_test_session_config() -> SessionConfig {
         address: create_test_address(),
         version: 2,
         credentials: SnmpCredentials::Community {
-            community: "public".to_string(),
+            community: "test-community".to_string(),
         },
         timeout: Duration::from_secs(5),
         retries: 3,

--- a/crates/unet-core/src/snmp/config.rs
+++ b/crates/unet-core/src/snmp/config.rs
@@ -27,7 +27,7 @@ pub enum SnmpCredentials {
 impl Default for SnmpCredentials {
     fn default() -> Self {
         Self::Community {
-            community: "public".to_string(),
+            community: String::new(),
         }
     }
 }

--- a/crates/unet-core/src/snmp/config/tests.rs
+++ b/crates/unet-core/src/snmp/config/tests.rs
@@ -12,7 +12,7 @@ mod snmp_config_tests {
         let creds = SnmpCredentials::default();
         match creds {
             SnmpCredentials::Community { community } => {
-                assert_eq!(community, "public");
+                assert!(community.is_empty());
             }
             SnmpCredentials::UserBased { .. } => panic!("Expected Community credentials"),
         }
@@ -96,7 +96,7 @@ mod snmp_config_tests {
         // Test default credentials
         match config.credentials {
             SnmpCredentials::Community { community } => {
-                assert_eq!(community, "public");
+                assert!(community.is_empty());
             }
             SnmpCredentials::UserBased { .. } => panic!("Expected Community credentials"),
         }

--- a/crates/unet-core/src/snmp/mod.rs
+++ b/crates/unet-core/src/snmp/mod.rs
@@ -139,7 +139,7 @@ mod tests {
         let creds = SnmpCredentials::default();
         match creds {
             SnmpCredentials::Community { community } => {
-                assert_eq!(community, "public");
+                assert!(community.is_empty());
             }
             SnmpCredentials::UserBased { .. } => panic!("Expected community credentials"),
         }
@@ -176,7 +176,7 @@ mod tests {
             address,
             version: 2,
             credentials: SnmpCredentials::Community {
-                community: "public".to_string(),
+                community: "test-community".to_string(),
             },
             timeout: Duration::from_secs(5),
             retries: 3,

--- a/crates/unet-core/src/snmp/session/core.rs
+++ b/crates/unet-core/src/snmp/session/core.rs
@@ -40,6 +40,11 @@ impl SnmpSession {
     pub(super) async fn create_client(config: &SessionConfig) -> SnmpResult<Snmp2cClient> {
         match &config.credentials {
             SnmpCredentials::Community { community } => {
+                if community.trim().is_empty() {
+                    return Err(SnmpError::Protocol {
+                        message: "SNMP community must be configured explicitly".to_string(),
+                    });
+                }
                 let client = Snmp2cClient::new(
                     config.address,
                     community.as_bytes().to_vec(),

--- a/crates/unet-core/src/snmp/session/core_tests.rs
+++ b/crates/unet-core/src/snmp/session/core_tests.rs
@@ -7,7 +7,7 @@ fn create_test_config() -> SessionConfig {
         address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 161),
         version: 2,
         credentials: SnmpCredentials::Community {
-            community: "public".to_string(),
+            community: "test-community".to_string(),
         },
         timeout: Duration::from_secs(5),
         retries: 3,
@@ -109,6 +109,19 @@ async fn test_create_client_community() {
     match result {
         Ok(_) | Err(SnmpError::Protocol { .. }) => {}
         Err(error) => panic!("Unexpected error type: {error:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_client_requires_explicit_community() {
+    let config = SessionConfig::default();
+
+    let result = SnmpSession::create_client(&config).await;
+    assert!(result.is_err());
+    if let Err(SnmpError::Protocol { message }) = result {
+        assert!(message.contains("SNMP community must be configured explicitly"));
+    } else {
+        panic!("Expected protocol error for missing SNMP community");
     }
 }
 

--- a/crates/unet-core/src/snmp/session/operations.rs
+++ b/crates/unet-core/src/snmp/session/operations.rs
@@ -149,7 +149,7 @@ mod tests {
             address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 161),
             version: 2,
             credentials: SnmpCredentials::Community {
-                community: "public".to_string(),
+                community: "test-community".to_string(),
             },
             timeout: Duration::from_secs(5),
             retries: 3,

--- a/crates/unet-server/src/config_loader.rs
+++ b/crates/unet-server/src/config_loader.rs
@@ -238,8 +238,46 @@ level = "info"
 
     #[test]
     fn test_initialize_app() {
+        let mut temp_file = NamedTempFile::with_suffix(".toml").unwrap();
+        writeln!(
+            temp_file,
+            r#"
+[database]
+url = "sqlite://test.db"
+max_connections = 10
+timeout = 30
+
+[logging]
+level = "info"
+format = "text"
+
+[snmp]
+community = "test-community"
+timeout = 5
+retries = 3
+
+[server]
+host = "0.0.0.0"
+port = 3000
+max_request_size = 1048576
+
+[git]
+branch = "main"
+sync_interval = 300
+
+[domain]
+default_domain = "example.com"
+search_domains = []
+
+[auth]
+enabled = false
+token = "bed-24-secret"
+"#
+        )
+        .unwrap();
+
         let args = Args {
-            config: None,
+            config: Some(temp_file.path().to_path_buf()),
             host: Some("127.0.0.1".to_string()),
             port: Some(8080),
             database_url: "sqlite://test.db".to_string(),
@@ -253,5 +291,25 @@ level = "info"
         assert_eq!(config.server.port, 8080);
         assert_eq!(config.logging.level, "warn");
         assert_eq!(db_url, "sqlite://test.db");
+    }
+
+    #[test]
+    fn test_initialize_app_requires_explicit_snmp_community() {
+        let args = Args {
+            config: None,
+            host: Some("127.0.0.1".to_string()),
+            port: Some(8080),
+            database_url: "sqlite://test.db".to_string(),
+            log_level: Some("warn".to_string()),
+        };
+
+        let result = initialize_app(&args);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("SNMP community must be configured explicitly")
+        );
     }
 }

--- a/crates/unet-server/src/main.rs
+++ b/crates/unet-server/src/main.rs
@@ -19,7 +19,51 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod main_tests {
     use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
     use unet_server::config_loader::Args;
+
+    fn write_valid_config_file() -> NamedTempFile {
+        let mut temp_file = NamedTempFile::with_suffix(".toml").unwrap();
+        writeln!(
+            temp_file,
+            r#"
+[database]
+url = "sqlite://test.db"
+max_connections = 10
+timeout = 30
+
+[logging]
+level = "warn"
+format = "text"
+
+[snmp]
+community = "test-community"
+timeout = 5
+retries = 3
+
+[server]
+host = "0.0.0.0"
+port = 9000
+max_request_size = 1048576
+
+[git]
+branch = "main"
+sync_interval = 300
+
+[domain]
+default_domain = "example.com"
+search_domains = []
+
+[auth]
+enabled = false
+token = "bed-24-secret"
+"#
+        )
+        .unwrap();
+        temp_file.flush().unwrap();
+        temp_file
+    }
 
     #[tokio::test]
     async fn test_args_parsing() {
@@ -41,9 +85,9 @@ mod main_tests {
 
     #[test]
     fn test_initialize_app_functionality() {
-        // Test initialize_app function call (covers line 21)
+        let temp_file = write_valid_config_file();
         let args = Args {
-            config: None,
+            config: Some(temp_file.path().to_path_buf()),
             host: Some("127.0.0.1".to_string()),
             port: Some(3000),
             database_url: "sqlite://test.db".to_string(),
@@ -61,23 +105,7 @@ mod main_tests {
 
     #[test]
     fn test_initialize_app_with_config_file() {
-        // Test initialize_app with config file
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
-        let mut temp_file = NamedTempFile::new().unwrap();
-        writeln!(
-            temp_file,
-            r#"
-[server]
-host = "0.0.0.0"
-port = 9000
-
-[logging]
-level = "warn"
-"#
-        )
-        .unwrap();
+        let temp_file = write_valid_config_file();
 
         let args = Args {
             config: Some(temp_file.path().to_path_buf()),
@@ -88,14 +116,12 @@ level = "warn"
         };
 
         let result = initialize_app(&args);
-        // Config loading might fail in test environment, just verify it doesn't panic
-        if let Ok((config, database_url)) = result {
-            assert!(!config.server.host.is_empty());
-            assert!(config.server.port > 0);
-            assert!(!database_url.is_empty());
-        } else {
-            // Config loading can fail in test environments, that's okay
-        }
+        assert!(result.is_ok());
+        let (config, database_url) = result.unwrap();
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.port, 9000);
+        assert_eq!(config.snmp.community, "test-community");
+        assert_eq!(database_url, "sqlite://test.db");
     }
 
     // Note: We can't easily test the actual main() function and server::run()

--- a/crates/unet-server/src/server/auth_tests.rs
+++ b/crates/unet-server/src/server/auth_tests.rs
@@ -72,7 +72,7 @@ level = "info"
 format = "text"
 
 [snmp]
-community = "public"
+community = "test-community"
 timeout = 5
 retries = 3
 

--- a/crates/unet-server/src/tests/integration_tests.rs
+++ b/crates/unet-server/src/tests/integration_tests.rs
@@ -7,8 +7,43 @@ use unet_core::config::Config;
 
 #[tokio::test]
 async fn test_initialize_app_with_overrides() {
+    let mut temp_file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+    writeln!(
+        temp_file,
+        r#"
+[database]
+url = "sqlite://test.db"
+
+[server]
+host = "127.0.0.1"
+port = 8080
+max_request_size = 1048576
+
+[logging]
+level = "info"
+format = "text"
+
+[snmp]
+community = "test-community"
+timeout = 5
+retries = 3
+
+[git]
+branch = "main"
+sync_interval = 300
+
+[domain]
+search_domains = []
+
+[auth]
+enabled = false
+token = ""
+"#
+    )
+    .unwrap();
+
     let args = Args {
-        config: None,
+        config: Some(temp_file.path().to_path_buf()),
         host: Some("0.0.0.0".to_string()),
         port: Some(9000),
         database_url: "sqlite://test.db".to_string(),
@@ -37,15 +72,7 @@ async fn test_initialize_app_with_defaults() {
     };
 
     let result = initialize_app(args).await;
-    assert!(result.is_ok());
-
-    let (config, database_url) = result.unwrap();
-
-    let default_config = Config::default();
-    assert_eq!(config.server.host, default_config.server.host);
-    assert_eq!(config.server.port, default_config.server.port);
-    assert_eq!(config.logging.level, default_config.logging.level);
-    assert_eq!(database_url, default_config.database_url());
+    assert!(result.is_err());
 }
 
 #[tokio::test]
@@ -81,7 +108,7 @@ level = "info"
 format = "text"
 
 [snmp]
-community = "public"
+community = "test-community"
 timeout = 5
 retries = 3
 
@@ -124,6 +151,7 @@ token_expiry = 3600
 #[test]
 fn test_config_validation_success() {
     let mut config = Config::default();
+    config.snmp.community = "test-community".to_string();
     config.server.port = 8080;
     assert!(config.validate().is_ok());
 }
@@ -147,7 +175,7 @@ level = "debug"
 format = "json"
 
 [snmp]
-community = "public"
+community = "test-community"
 timeout = 5
 retries = 3
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -360,7 +360,7 @@ done
 unet nodes show node-name | grep management_ip
 
 # 2. Test SNMP connectivity manually
-snmpget -v2c -c public 192.168.1.1 1.3.6.1.2.1.1.1.0
+snmpget -v2c -c <community> 192.168.1.1 1.3.6.1.2.1.1.1.0
 
 # 3. Check server logs for SNMP errors
 unet-server --log-level debug | grep -i snmp
@@ -386,8 +386,8 @@ curl http://localhost:8080/api/v1/nodes/node-id/status
 # 2. Verify management IP is set
 unet nodes update node-name --management-ip 192.168.1.1
 
-# 3. Check SNMP credentials (when implemented)
-# Currently uses default community "public"
+# 3. Check SNMP credentials
+# Configure an explicit SNMP community or SNMPv3 credentials before polling
 
 # 4. Monitor polling in server logs
 unet-server --log-level debug | grep -i "snmp\|polling"


### PR DESCRIPTION
## Summary
- remove the runtime/default SNMP community `public` from config and session defaults
- require explicit SNMP community configuration during startup and before creating SNMPv2c sessions
- update troubleshooting guidance and regression tests to reflect the explicit-credentials contract

## Testing
- `mise run test -- -p unet-core test_config_default_snmp_community_is_empty`
- `mise run test -- -p unet-core test_config_validate_default_config_requires_snmp_community`
- `mise run test -- -p unet-core test_snmp_credentials_default`
- `mise run test -- -p unet-core test_create_client_requires_explicit_community`
- `mise run test -- -p unet-server test_initialize_app`
- `mise run test -- -p unet-server test_initialize_app_requires_explicit_snmp_community`
- `mise run test -- -p unet-server test_initialize_app_functionality`
- `mise run test -- -p unet-server test_initialize_app_with_config_file`
- `mise run lint`
- `mise run check-large-files`

## Manual QA
- start `unet-server` without an explicit SNMP community and confirm startup fails with `SNMP community must be configured explicitly`
- start `unet-server` with a config file that provides an SNMP community and confirm initialization succeeds

## Links
- Linear: https://linear.app/bede/issue/BED-27/remove-insecure-default-snmp-community-public-from-runtime-defaults
