### PR TITLE
Make status and CI lint tasks read-only

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,6 +19,12 @@ slow-timeout = { period = "1000ms", terminate-after = 4 }
 filter = "test(test_list_link_args_creation) | test(test_update_link_args_creation)"
 slow-timeout = { period = "500ms", terminate-after = 4 }
 
+# These error-conversion/reporting tests complete their assertions quickly but
+# can take longer to tear down under `llvm-cov` instrumentation.
+[[profile.default.overrides]]
+filter = "test(test_serde_json_error_serialization) | test(test_error_log_template_error) | test(test_error_log_snmp_error) | test(test_error_log_validation_error_without_value)"
+slow-timeout = { period = "1000ms", terminate-after = 6 }
+
 # CI profile with JUnit XML generation for Codecov Test Analytics
 [profile.ci]
 # Inherit from default profile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ derived state (SNMP polling)
 - **NEVER** assume file locations - search first
 - **ALWAYS** use Read tool before Edit/MultiEdit operations
 - **ALWAYS** run `mise run lint` after code changes
+- **USE** `mise run lint-fix` when local auto-fixes are desired
 - **NEVER** skip the TodoWrite tool for multi-step tasks
 - **REFERENCE** `docs/src/developer_guide.md` for detailed implementation patterns and decision trees
 
@@ -212,7 +213,8 @@ unet/
 
 ### Development Tools (mise.toml)
 
-- **linting:** `mise run lint` - lints and auto-fixes linting issues (typos, clippy, formatting)
+- **linting:** `mise run lint` - runs read-only typo, formatting, and clippy checks
+- **autofix:** `mise run lint-fix` - applies typo, formatting, and clippy fixes locally
 - **testing:** `mise run test` - runs unit tests with nextest
 - **coverage:** `mise run coverage` - generates code coverage reports with `llvm-cov`
 - **file size check:** `mise run check-large-files` - reports Rust files above the `300`-line target and fails on hard-limit regressions above `500`
@@ -234,7 +236,7 @@ Note: `mise run test` and `mise run coverage` can be long-running and produce la
 
 - **LLM overview:** Run `mise run status` to check clippy, run tests with coverage, and get a concise summary. Inspect `target/mise-logs/latest/` for full logs.
 - **TDD loops:** Use `mise run test -- <filters>` (package and/or name patterns) to iterate quickly; confirm failures first, then implement minimal code.
-- **Before commit:** Run `mise run lint` to auto-fix formatting/typos and surface clippy issues; run `mise run check-large-files` to review advisory offenders and catch hard-limit regressions.
+- **Before commit:** Run `mise run lint` to verify formatting/typo/clippy checks without rewriting files. When local auto-fixes are desired, run `mise run lint-fix` before the final read-only lint pass. Run `mise run check-large-files` to review advisory offenders and catch hard-limit regressions.
 - **CI-only tasks:** `ci-*` tasks are invoked by GitHub Actions; do not modify without coordinating with CI config.
 
 ### Nextest Usage Patterns
@@ -308,13 +310,16 @@ vim crates/unet-core/src/models/node.rs
 # 6. Run tests after each refactoring step
 mise run test
 
-# 7. Check if any manual fixes are needed, will format code
+# 7. Apply local auto-fixes if needed
+mise run lint-fix
+
+# 8. Verify read-only lint passes
 mise run lint
 
-# 8. Generate coverage report to ensure adequate test coverage
+# 9. Generate coverage report to ensure adequate test coverage
 mise run coverage
 
-# 9. Verify file sizes are within guidelines
+# 10. Verify file sizes are within guidelines
 mise run check-large-files
 ```
 

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -2,4 +2,3 @@
 
 pub mod logging;
 pub mod sqlite;
-

--- a/crates/test-support/src/logging.rs
+++ b/crates/test-support/src/logging.rs
@@ -12,4 +12,3 @@ pub fn init_tracing_once() {
             .try_init();
     });
 }
-

--- a/crates/test-support/src/sqlite.rs
+++ b/crates/test-support/src/sqlite.rs
@@ -1,7 +1,7 @@
+use sea_orm::Statement;
 use sea_orm::{ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Schema};
 use tokio::sync::OnceCell;
 use unet_core::entities;
-use sea_orm::Statement;
 
 static DB_CONN: OnceCell<DatabaseConnection> = OnceCell::const_new();
 
@@ -19,7 +19,9 @@ pub async fn entity_db() -> DatabaseConnection {
         .clone()
 }
 
-async fn apply_entity_schema(connection: &impl ConnectionTrait) -> Result<(), Box<dyn std::error::Error>> {
+async fn apply_entity_schema(
+    connection: &impl ConnectionTrait,
+) -> Result<(), Box<dyn std::error::Error>> {
     let schema = Schema::new(DatabaseBackend::Sqlite);
 
     for stmt in [
@@ -40,7 +42,9 @@ async fn apply_entity_schema(connection: &impl ConnectionTrait) -> Result<(), Bo
     use sea_orm::{ActiveModelTrait, Set};
     let vendor_names = ["Cisco", "Juniper"];
     for name in vendor_names {
-        let active = entities::vendors::ActiveModel { name: Set(name.to_string()) };
+        let active = entities::vendors::ActiveModel {
+            name: Set(name.to_string()),
+        };
         let _ = active.insert(connection).await; // ignore errors if already seeded
     }
     Ok(())
@@ -64,16 +68,12 @@ where
     let save = format!("SAVEPOINT {name}");
     let rollback = format!("ROLLBACK TO {name}");
     let release = format!("RELEASE {name}");
-    let _ = conn
-        .execute(Statement::from_string(backend, save))
-        .await;
+    let _ = conn.execute(Statement::from_string(backend, save)).await;
     let store = unet_core::datastore::sqlite::SqliteStore::from_connection(conn.clone());
     let out = f(store).await;
     let _ = conn
         .execute(Statement::from_string(backend, rollback))
         .await;
-    let _ = conn
-        .execute(Statement::from_string(backend, release))
-        .await;
+    let _ = conn.execute(Statement::from_string(backend, release)).await;
     out
 }

--- a/crates/unet-cli/src/commands/export.rs
+++ b/crates/unet-cli/src/commands/export.rs
@@ -264,8 +264,6 @@ async fn export_links(args: &ExportArgs, datastore: &dyn DataStore) -> Result<us
 mod tests {
     use super::*;
     use tempfile::TempDir;
-    
-    
 
     #[tokio::test]
     async fn test_export_stats_new() {
@@ -382,7 +380,7 @@ mod exec_tests {
     use super::*;
     use mockall::predicate::always;
     use tempfile::TempDir;
-    use unet_core::datastore::{types::PagedResult, MockDataStore};
+    use unet_core::datastore::{MockDataStore, types::PagedResult};
     use unet_core::models::{DeviceRole, NodeBuilder, Vendor};
 
     #[tokio::test]
@@ -399,7 +397,12 @@ mod exec_tests {
             .with(always())
             .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
 
-        let args = ExportArgs { to: temp.path().to_path_buf(), format: "json".into(), force: false, only: None };
+        let args = ExportArgs {
+            to: temp.path().to_path_buf(),
+            format: "json".into(),
+            force: false,
+            only: None,
+        };
         let res = execute(args, &mock, crate::OutputFormat::Json).await;
         assert!(res.is_ok());
     }
@@ -424,17 +427,20 @@ mod exec_tests {
         mock.expect_list_locations()
             .with(always())
             .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
-        mock.expect_list_nodes()
-            .with(always())
-            .returning(move |_| {
-                let n = node.clone();
-                Box::pin(async move { Ok(PagedResult::new(vec![n], 1, None)) })
-            });
+        mock.expect_list_nodes().with(always()).returning(move |_| {
+            let n = node.clone();
+            Box::pin(async move { Ok(PagedResult::new(vec![n], 1, None)) })
+        });
         mock.expect_list_links()
             .with(always())
             .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
 
-        let args = ExportArgs { to: temp.path().to_path_buf(), format: "json".into(), force: false, only: Some(vec!["nodes".into()]) };
+        let args = ExportArgs {
+            to: temp.path().to_path_buf(),
+            format: "json".into(),
+            force: false,
+            only: Some(vec!["nodes".into()]),
+        };
         let res = execute(args, &mock, crate::OutputFormat::Json).await;
         assert!(res.is_err());
     }
@@ -442,7 +448,7 @@ mod exec_tests {
     #[tokio::test]
     async fn test_execute_locations_yaml_writes_file() {
         use mockall::predicate::always;
-        use unet_core::datastore::{types::PagedResult, MockDataStore};
+        use unet_core::datastore::{MockDataStore, types::PagedResult};
         use unet_core::models::Location;
         let temp = TempDir::new().unwrap();
         let loc = Location::new_root("HQ".into(), "building".into());
@@ -462,7 +468,12 @@ mod exec_tests {
             .with(always())
             .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
 
-        let args = ExportArgs { to: temp.path().to_path_buf(), format: "yaml".into(), force: true, only: Some(vec!["locations".into()]) };
+        let args = ExportArgs {
+            to: temp.path().to_path_buf(),
+            format: "yaml".into(),
+            force: true,
+            only: Some(vec!["locations".into()]),
+        };
         let res = execute(args, &mock, crate::OutputFormat::Json).await;
         assert!(res.is_ok());
         // Verify file exists
@@ -473,7 +484,7 @@ mod exec_tests {
     #[tokio::test]
     async fn test_execute_links_json_writes_file() {
         use mockall::predicate::always;
-        use unet_core::datastore::{types::PagedResult, MockDataStore};
+        use unet_core::datastore::{MockDataStore, types::PagedResult};
         let temp = TempDir::new().unwrap();
         let a = uuid::Uuid::new_v4();
         let z = uuid::Uuid::new_v4();
@@ -486,14 +497,17 @@ mod exec_tests {
         mock.expect_list_nodes()
             .with(always())
             .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
-        mock.expect_list_links()
-            .with(always())
-            .returning(move |_| {
-                let l = link.clone();
-                Box::pin(async move { Ok(PagedResult::new(vec![l], 1, None)) })
-            });
+        mock.expect_list_links().with(always()).returning(move |_| {
+            let l = link.clone();
+            Box::pin(async move { Ok(PagedResult::new(vec![l], 1, None)) })
+        });
 
-        let args = ExportArgs { to: temp.path().to_path_buf(), format: "json".into(), force: true, only: Some(vec!["links".into()]) };
+        let args = ExportArgs {
+            to: temp.path().to_path_buf(),
+            format: "json".into(),
+            force: true,
+            only: Some(vec!["links".into()]),
+        };
         let res = execute(args, &mock, crate::OutputFormat::Json).await;
         assert!(res.is_ok());
         let out = temp.path().join("links.json");
@@ -503,23 +517,30 @@ mod exec_tests {
     #[tokio::test]
     async fn test_execute_unsupported_format_errors() {
         use mockall::predicate::always;
-        use unet_core::datastore::{types::PagedResult, MockDataStore};
+        use unet_core::datastore::{MockDataStore, types::PagedResult};
         let temp = TempDir::new().unwrap();
         let mut mock = MockDataStore::new();
-        mock.expect_list_locations()
-            .with(always())
-            .returning(|_| {
-                let loc = unet_core::models::location::model::Location::new_root(
-                    "HQ".into(),
-                    "building".into(),
-                );
-                Box::pin(async move { Ok(PagedResult::new(vec![loc], 1, None)) })
-            });
+        mock.expect_list_locations().with(always()).returning(|_| {
+            let loc = unet_core::models::location::model::Location::new_root(
+                "HQ".into(),
+                "building".into(),
+            );
+            Box::pin(async move { Ok(PagedResult::new(vec![loc], 1, None)) })
+        });
         // keep nodes/links empty
-        mock.expect_list_nodes().with(always()).returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
-        mock.expect_list_links().with(always()).returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
+        mock.expect_list_nodes()
+            .with(always())
+            .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
+        mock.expect_list_links()
+            .with(always())
+            .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
 
-        let args = ExportArgs { to: temp.path().to_path_buf(), format: "xml".into(), force: true, only: Some(vec!["locations".into()]) };
+        let args = ExportArgs {
+            to: temp.path().to_path_buf(),
+            format: "xml".into(),
+            force: true,
+            only: Some(vec!["locations".into()]),
+        };
         let res = execute(args, &mock, crate::OutputFormat::Json).await;
         assert!(res.is_err());
     }

--- a/crates/unet-cli/src/commands/import/mod.rs
+++ b/crates/unet-cli/src/commands/import/mod.rs
@@ -167,7 +167,12 @@ mod exec_tests {
     async fn test_execute_import_no_files_ok() {
         let temp = TempDir::new().unwrap();
         let mock = MockDataStore::new();
-        let args = ImportArgs { from: temp.path().to_path_buf(), format: None, dry_run: true, continue_on_error: false };
+        let args = ImportArgs {
+            from: temp.path().to_path_buf(),
+            format: None,
+            dry_run: true,
+            continue_on_error: false,
+        };
         let res = execute(args, &mock, crate::OutputFormat::Json).await;
         assert!(res.is_ok());
     }
@@ -177,17 +182,48 @@ mod exec_tests {
         let temp = TempDir::new().unwrap();
         // Write minimal valid JSON files for locations, nodes, links
         let loc = Location::new_root("HQ".into(), "building".into());
-        let mut node = Node::new("n1".into(), "example.com".into(), Vendor::Cisco, DeviceRole::Router);
+        let mut node = Node::new(
+            "n1".into(),
+            "example.com".into(),
+            Vendor::Cisco,
+            DeviceRole::Router,
+        );
         node.model = "ISR".into();
-        let link = unet_core::models::Link::new("L1".into(), Uuid::new_v4(), "Gi0/0".into(), Uuid::new_v4(), "Gi0/1".into());
+        let link = unet_core::models::Link::new(
+            "L1".into(),
+            Uuid::new_v4(),
+            "Gi0/0".into(),
+            Uuid::new_v4(),
+            "Gi0/1".into(),
+        );
 
-        tokio::fs::write(temp.path().join("locations.json"), serde_json::to_string_pretty(&vec![loc]).unwrap()).await.unwrap();
-        tokio::fs::write(temp.path().join("nodes.json"), serde_json::to_string_pretty(&vec![node]).unwrap()).await.unwrap();
-        tokio::fs::write(temp.path().join("links.json"), serde_json::to_string_pretty(&vec![link]).unwrap()).await.unwrap();
+        tokio::fs::write(
+            temp.path().join("locations.json"),
+            serde_json::to_string_pretty(&vec![loc]).unwrap(),
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(
+            temp.path().join("nodes.json"),
+            serde_json::to_string_pretty(&vec![node]).unwrap(),
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(
+            temp.path().join("links.json"),
+            serde_json::to_string_pretty(&vec![link]).unwrap(),
+        )
+        .await
+        .unwrap();
 
         // dry_run means no datastore calls are performed, so mock without expectations
         let mock = MockDataStore::new();
-        let args = ImportArgs { from: temp.path().to_path_buf(), format: None, dry_run: true, continue_on_error: false };
+        let args = ImportArgs {
+            from: temp.path().to_path_buf(),
+            format: None,
+            dry_run: true,
+            continue_on_error: false,
+        };
         let res = execute(args, &mock, crate::OutputFormat::Json).await;
         assert!(res.is_ok());
     }

--- a/crates/unet-cli/src/commands/import/processors.rs
+++ b/crates/unet-cli/src/commands/import/processors.rs
@@ -139,7 +139,12 @@ mod tests {
                 Box::pin(async move { Ok(l) })
             });
         // A bit of a hack: ignore return value type specifics; we only assert Ok path
-        let _ = import_location(&Location::new_root("HQ".into(), "building".into()), &mock, false).await;
+        let _ = import_location(
+            &Location::new_root("HQ".into(), "building".into()),
+            &mock,
+            false,
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -167,7 +172,13 @@ mod tests {
     #[tokio::test]
     async fn test_import_link_dry_run_and_real() {
         use unet_core::models::Link;
-        let link = Link::new("L1".into(), Uuid::new_v4(), "Gi0/0".into(), Uuid::new_v4(), "Gi0/1".into());
+        let link = Link::new(
+            "L1".into(),
+            Uuid::new_v4(),
+            "Gi0/0".into(),
+            Uuid::new_v4(),
+            "Gi0/1".into(),
+        );
         let mut mock = MockDataStore::new();
         assert!(import_link(&link, &mock, true).await.is_ok());
         let link_clone = link.clone();

--- a/crates/unet-cli/src/commands/import/stats.rs
+++ b/crates/unet-cli/src/commands/import/stats.rs
@@ -149,7 +149,13 @@ mod process_tests {
     #[tokio::test]
     async fn test_process_import_item_error_continue() {
         let mut stats = ImportStats::new();
-        let res = process_import_item(|| async { Err(anyhow::anyhow!("boom")) }, "node 'n1'", true, &mut stats).await;
+        let res = process_import_item(
+            || async { Err(anyhow::anyhow!("boom")) },
+            "node 'n1'",
+            true,
+            &mut stats,
+        )
+        .await;
         assert!(res.is_ok());
         assert_eq!(stats.success_count(), 0);
         assert_eq!(stats.error_count(), 1);
@@ -158,7 +164,13 @@ mod process_tests {
     #[tokio::test]
     async fn test_process_import_item_error_stop() {
         let mut stats = ImportStats::new();
-        let res = process_import_item(|| async { Err(anyhow::anyhow!("boom")) }, "node 'n1'", false, &mut stats).await;
+        let res = process_import_item(
+            || async { Err(anyhow::anyhow!("boom")) },
+            "node 'n1'",
+            false,
+            &mut stats,
+        )
+        .await;
         assert!(res.is_err());
         assert_eq!(stats.success_count(), 0);
         assert_eq!(stats.error_count(), 1);

--- a/crates/unet-cli/src/commands/links.rs
+++ b/crates/unet-cli/src/commands/links.rs
@@ -33,7 +33,7 @@ mod dispatch_tests {
     use super::*;
     use crate::commands::links::types::ListLinkArgs;
     use mockall::predicate::always;
-    use unet_core::datastore::{types::PagedResult, MockDataStore};
+    use unet_core::datastore::{MockDataStore, types::PagedResult};
 
     #[tokio::test]
     async fn test_execute_list_links_dispatch() {
@@ -42,7 +42,12 @@ mod dispatch_tests {
             .with(always())
             .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
 
-        let args = ListLinkArgs { node_id: None, min_bandwidth: None, page: 1, per_page: 20 };
+        let args = ListLinkArgs {
+            node_id: None,
+            min_bandwidth: None,
+            page: 1,
+            per_page: 20,
+        };
 
         let res = execute(
             types::LinkCommands::List(args),

--- a/crates/unet-cli/src/commands/links/crud.rs
+++ b/crates/unet-cli/src/commands/links/crud.rs
@@ -195,10 +195,7 @@ pub fn confirm_link_deletion(
     println!(
         "Are you sure you want to delete link {} <-> {} (ID: {})? [y/N]",
         link.node_a_interface,
-        link
-            .node_z_interface
-            .as_deref()
-            .unwrap_or("internet"),
+        link.node_z_interface.as_deref().unwrap_or("internet"),
         link.id
     );
     let mut input = String::new();

--- a/crates/unet-cli/src/commands/locations.rs
+++ b/crates/unet-cli/src/commands/locations.rs
@@ -37,7 +37,7 @@ mod dispatch_tests {
     use super::*;
     use crate::commands::locations::types::ListLocationArgs;
     use mockall::predicate::always;
-    use unet_core::datastore::{types::PagedResult, MockDataStore};
+    use unet_core::datastore::{MockDataStore, types::PagedResult};
 
     #[tokio::test]
     async fn test_execute_list_locations_dispatch() {
@@ -46,7 +46,12 @@ mod dispatch_tests {
             .with(always())
             .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
 
-        let args = ListLocationArgs { location_type: None, parent_id: None, page: 1, per_page: 20 };
+        let args = ListLocationArgs {
+            location_type: None,
+            parent_id: None,
+            page: 1,
+            per_page: 20,
+        };
 
         let res = execute(
             types::LocationCommands::List(args),

--- a/crates/unet-cli/src/commands/policy/dispatch_tests.rs
+++ b/crates/unet-cli/src/commands/policy/dispatch_tests.rs
@@ -1,10 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use crate::commands::policy::{execute, DiffPolicyArgs, EvalPolicyArgs, ListPolicyArgs, PolicyCommands, ShowPolicyArgs, ValidatePolicyArgs};
+    use crate::commands::policy::{
+        DiffPolicyArgs, EvalPolicyArgs, ListPolicyArgs, PolicyCommands, ShowPolicyArgs,
+        ValidatePolicyArgs, execute,
+    };
     use mockall::predicate::eq;
     use std::io::Write;
     use tempfile::{NamedTempFile, TempDir};
-    use unet_core::datastore::{types::PagedResult, MockDataStore};
+    use unet_core::datastore::{MockDataStore, types::PagedResult};
     use unet_core::models::{DeviceRole, NodeBuilder, Vendor};
     use uuid::Uuid;
 
@@ -42,7 +45,11 @@ mod tests {
     #[tokio::test]
     async fn test_execute_eval_no_nodes() {
         let mut tf = NamedTempFile::new().unwrap();
-        writeln!(tf, "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\"").unwrap();
+        writeln!(
+            tf,
+            "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\""
+        )
+        .unwrap();
 
         let args = EvalPolicyArgs {
             path: tf.path().into(),
@@ -62,7 +69,11 @@ mod tests {
     #[tokio::test]
     async fn test_execute_diff_with_node() {
         let mut tf = NamedTempFile::new().unwrap();
-        writeln!(tf, "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\"").unwrap();
+        writeln!(
+            tf,
+            "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\""
+        )
+        .unwrap();
 
         let node = make_node();
         let node_id = node.id;
@@ -90,7 +101,11 @@ mod tests {
     async fn test_execute_list() {
         let dir = TempDir::new().unwrap();
         let policy_file = dir.path().join("valid.policy");
-        std::fs::write(&policy_file, "WHEN TRUE THEN ASSERT node.role IS \"router\"").unwrap();
+        std::fs::write(
+            &policy_file,
+            "WHEN TRUE THEN ASSERT node.role IS \"router\"",
+        )
+        .unwrap();
 
         let args = ListPolicyArgs {
             path: dir.path().into(),
@@ -105,7 +120,11 @@ mod tests {
     #[tokio::test]
     async fn test_execute_show() {
         let mut tf = NamedTempFile::new().unwrap();
-        writeln!(tf, "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\"").unwrap();
+        writeln!(
+            tf,
+            "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\""
+        )
+        .unwrap();
 
         let args = ShowPolicyArgs {
             path: tf.path().into(),

--- a/crates/unet-cli/src/commands/policy/eval.rs
+++ b/crates/unet-cli/src/commands/policy/eval.rs
@@ -37,10 +37,10 @@ pub async fn eval_policy(args: EvalPolicyArgs, datastore: &dyn DataStore) -> Res
 #[cfg(test)]
 mod e2e_light_tests {
     use mockall::predicate::eq;
-    use tempfile::NamedTempFile;
-    use unet_core::datastore::{types::PagedResult, MockDataStore};
-    use unet_core::models::{DeviceRole, NodeBuilder, Vendor};
     use std::io::Write;
+    use tempfile::NamedTempFile;
+    use unet_core::datastore::{MockDataStore, types::PagedResult};
+    use unet_core::models::{DeviceRole, NodeBuilder, Vendor};
 
     fn make_node_with_version(ver: &str) -> unet_core::models::Node {
         NodeBuilder::new()
@@ -58,14 +58,23 @@ mod e2e_light_tests {
     async fn test_eval_policy_no_nodes_branch() {
         // Write a minimal valid policy file
         let mut f = NamedTempFile::new().unwrap();
-        writeln!(f, "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\"").unwrap();
+        writeln!(
+            f,
+            "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\""
+        )
+        .unwrap();
 
         let mut mock = MockDataStore::new();
         // Return empty nodes set
         mock.expect_list_nodes()
             .returning(|_| Box::pin(async { Ok(PagedResult::new(vec![], 0, None)) }));
 
-        let args = super::EvalPolicyArgs { path: f.path().into(), node_id: None, verbose: false, failures_only: false };
+        let args = super::EvalPolicyArgs {
+            path: f.path().into(),
+            node_id: None,
+            verbose: false,
+            failures_only: false,
+        };
         let res = super::eval_policy(args, &mock).await;
         assert!(res.is_ok());
     }
@@ -73,33 +82,46 @@ mod e2e_light_tests {
     #[tokio::test]
     async fn test_eval_and_diff_policy_with_nodes() {
         let mut f = NamedTempFile::new().unwrap();
-        writeln!(f, "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\"").unwrap();
+        writeln!(
+            f,
+            "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\""
+        )
+        .unwrap();
 
         let node = make_node_with_version("15.1");
         let node_id = node.id;
 
         let mut mock = MockDataStore::new();
         let node_for_list = node.clone();
-        mock.expect_list_nodes()
-            .returning(move |_| {
-                let n = node_for_list.clone();
-                Box::pin(async move { Ok(PagedResult::new(vec![n], 1, None)) })
-            });
+        mock.expect_list_nodes().returning(move |_| {
+            let n = node_for_list.clone();
+            Box::pin(async move { Ok(PagedResult::new(vec![n], 1, None)) })
+        });
 
-        let args = super::EvalPolicyArgs { path: f.path().into(), node_id: None, verbose: true, failures_only: false };
+        let args = super::EvalPolicyArgs {
+            path: f.path().into(),
+            node_id: None,
+            verbose: true,
+            failures_only: false,
+        };
         let res = super::eval_policy(args, &mock).await;
         assert!(res.is_ok());
 
         // diff_policy: pass case
         let mut mock2 = MockDataStore::new();
         let node_for_get = node.clone();
-        mock2.expect_get_node()
+        mock2
+            .expect_get_node()
             .with(eq(node_id))
             .returning(move |_| {
                 let n = node_for_get.clone();
                 Box::pin(async move { Ok(Some(n)) })
             });
-        let args2 = super::DiffPolicyArgs { path: f.path().into(), node_id, verbose: true };
+        let args2 = super::DiffPolicyArgs {
+            path: f.path().into(),
+            node_id,
+            verbose: true,
+        };
         let res2 = super::diff_policy(args2, &mock2).await;
         assert!(res2.is_ok());
     }
@@ -279,10 +301,12 @@ mod tests {
 
     #[cfg(test)]
     mod branch_tests {
-        use crate::commands::policy::eval::evaluate_node_policies;
         use crate::commands::policy::EvalPolicyArgs;
+        use crate::commands::policy::eval::evaluate_node_policies;
         use unet_core::models::{DeviceRole, NodeBuilder, Vendor};
-        use unet_core::policy::{Action, ComparisonOperator, Condition, FieldRef, PolicyRule, Value};
+        use unet_core::policy::{
+            Action, ComparisonOperator, Condition, FieldRef, PolicyRule, Value,
+        };
 
         fn make_node() -> unet_core::models::Node {
             NodeBuilder::new()
@@ -296,23 +320,61 @@ mod tests {
         }
 
         fn assert_rule_true() -> PolicyRule {
-            PolicyRule { id: None, condition: Condition::True, action: Action::Assert { field: FieldRef { path: vec!["node".into(), "vendor".into()] }, expected: Value::String("cisco".into()) } }
+            PolicyRule {
+                id: None,
+                condition: Condition::True,
+                action: Action::Assert {
+                    field: FieldRef {
+                        path: vec!["node".into(), "vendor".into()],
+                    },
+                    expected: Value::String("cisco".into()),
+                },
+            }
         }
 
         fn assert_rule_false() -> PolicyRule {
-            PolicyRule { id: None, condition: Condition::False, action: Action::Assert { field: FieldRef { path: vec!["node".into(), "vendor".into()] }, expected: Value::String("cisco".into()) } }
+            PolicyRule {
+                id: None,
+                condition: Condition::False,
+                action: Action::Assert {
+                    field: FieldRef {
+                        path: vec!["node".into(), "vendor".into()],
+                    },
+                    expected: Value::String("cisco".into()),
+                },
+            }
         }
 
         fn error_rule() -> PolicyRule {
             // Reference a non-existent field to trigger an evaluation error
-            PolicyRule { id: None, condition: Condition::Comparison { field: FieldRef { path: vec!["node".into(), "does_not_exist".into()] }, operator: ComparisonOperator::Equal, value: Value::String("x".into()) }, action: Action::Assert { field: FieldRef { path: vec!["node".into(), "vendor".into()] }, expected: Value::String("cisco".into()) } }
+            PolicyRule {
+                id: None,
+                condition: Condition::Comparison {
+                    field: FieldRef {
+                        path: vec!["node".into(), "does_not_exist".into()],
+                    },
+                    operator: ComparisonOperator::Equal,
+                    value: Value::String("x".into()),
+                },
+                action: Action::Assert {
+                    field: FieldRef {
+                        path: vec!["node".into(), "vendor".into()],
+                    },
+                    expected: Value::String("cisco".into()),
+                },
+            }
         }
 
         #[test]
         fn test_evaluate_node_policies_satisfied_verbose() {
             let node = make_node();
             let policies = vec![vec![assert_rule_true()]];
-            let args = EvalPolicyArgs { path: std::path::PathBuf::from("."), node_id: None, verbose: true, failures_only: false };
+            let args = EvalPolicyArgs {
+                path: std::path::PathBuf::from("."),
+                node_id: None,
+                verbose: true,
+                failures_only: false,
+            };
             let res = evaluate_node_policies(&node, &policies, &args);
             assert!(res.is_ok());
         }
@@ -321,7 +383,12 @@ mod tests {
         fn test_evaluate_node_policies_not_satisfied_failures_only() {
             let node = make_node();
             let policies = vec![vec![assert_rule_false()]];
-            let args = EvalPolicyArgs { path: std::path::PathBuf::from("."), node_id: None, verbose: false, failures_only: true };
+            let args = EvalPolicyArgs {
+                path: std::path::PathBuf::from("."),
+                node_id: None,
+                verbose: false,
+                failures_only: true,
+            };
             let res = evaluate_node_policies(&node, &policies, &args);
             assert!(res.is_ok());
         }
@@ -330,7 +397,12 @@ mod tests {
         fn test_evaluate_node_policies_error_branch() {
             let node = make_node();
             let policies = vec![vec![error_rule()]];
-            let args = EvalPolicyArgs { path: std::path::PathBuf::from("."), node_id: None, verbose: true, failures_only: true };
+            let args = EvalPolicyArgs {
+                path: std::path::PathBuf::from("."),
+                node_id: None,
+                verbose: true,
+                failures_only: true,
+            };
             let res = evaluate_node_policies(&node, &policies, &args);
             assert!(res.is_ok());
         }

--- a/crates/unet-cli/src/commands/policy/mod.rs
+++ b/crates/unet-cli/src/commands/policy/mod.rs
@@ -110,8 +110,8 @@ pub async fn execute(command: PolicyCommands, datastore: &dyn DataStore) -> Resu
 }
 
 #[cfg(test)]
+mod dispatch_tests;
+#[cfg(test)]
 mod eval_tests;
 #[cfg(test)]
 mod tests;
-#[cfg(test)]
-mod dispatch_tests;

--- a/crates/unet-cli/src/commands/vendors.rs
+++ b/crates/unet-cli/src/commands/vendors.rs
@@ -405,22 +405,28 @@ mod exec_tests {
         mock.expect_create_vendor()
             .with(eq("cisco"))
             .returning(|_| Box::pin(async { Ok(()) }));
-        assert!(execute(
-            VendorCommands::Add(AddVendorArgs { name: "cisco".into() }),
-            &mock,
-            crate::OutputFormat::Json
-        )
-        .await
-        .is_ok());
+        assert!(
+            execute(
+                VendorCommands::Add(AddVendorArgs {
+                    name: "cisco".into()
+                }),
+                &mock,
+                crate::OutputFormat::Json
+            )
+            .await
+            .is_ok()
+        );
 
         // List
         let mut mock_list = MockDataStore::new();
         mock_list
             .expect_list_vendors()
             .returning(|| Box::pin(async { Ok(vec!["cisco".into(), "juniper".into()]) }));
-        assert!(execute(VendorCommands::List, &mock_list, crate::OutputFormat::Json)
-            .await
-            .is_ok());
+        assert!(
+            execute(VendorCommands::List, &mock_list, crate::OutputFormat::Json)
+                .await
+                .is_ok()
+        );
 
         // Delete with yes flag skips stdin
         let mut mock_del = MockDataStore::new();
@@ -428,13 +434,18 @@ mod exec_tests {
             .expect_delete_vendor()
             .with(eq("cisco"))
             .returning(|_| Box::pin(async { Ok(()) }));
-        assert!(execute(
-            VendorCommands::Delete(DeleteVendorArgs { name: "cisco".into(), yes: true }),
-            &mock_del,
-            crate::OutputFormat::Json
-        )
-        .await
-        .is_ok());
+        assert!(
+            execute(
+                VendorCommands::Delete(DeleteVendorArgs {
+                    name: "cisco".into(),
+                    yes: true
+                }),
+                &mock_del,
+                crate::OutputFormat::Json
+            )
+            .await
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/unet-cli/src/dry_run.rs
+++ b/crates/unet-cli/src/dry_run.rs
@@ -1,7 +1,9 @@
-use std::sync::Arc;
 use async_trait::async_trait;
+use std::sync::Arc;
 use tracing::info;
-use unet_core::datastore::types::{BatchResult, DataStoreError, DataStoreResult, PagedResult, QueryOptions};
+use unet_core::datastore::types::{
+    BatchResult, DataStoreError, DataStoreResult, PagedResult, QueryOptions,
+};
 use unet_core::datastore::{BatchOperation, DataStore, Transaction};
 use unet_core::models::{Link, Location, Node};
 use unet_core::policy::PolicyExecutionResult;
@@ -12,23 +14,35 @@ pub struct DryRunStore {
 }
 
 impl DryRunStore {
-    pub fn new(inner: Arc<dyn DataStore>) -> Self { Self { inner } }
+    pub fn new(inner: Arc<dyn DataStore>) -> Self {
+        Self { inner }
+    }
 }
 
 #[async_trait]
 impl DataStore for DryRunStore {
-    fn name(&self) -> &'static str { "dry-run" }
+    fn name(&self) -> &'static str {
+        "dry-run"
+    }
 
-    async fn health_check(&self) -> DataStoreResult<()> { self.inner.health_check().await }
-    async fn begin_transaction(&self) -> DataStoreResult<Box<dyn Transaction>> { self.inner.begin_transaction().await }
+    async fn health_check(&self) -> DataStoreResult<()> {
+        self.inner.health_check().await
+    }
+    async fn begin_transaction(&self) -> DataStoreResult<Box<dyn Transaction>> {
+        self.inner.begin_transaction().await
+    }
 
     // Node ops
     async fn create_node(&self, node: &Node) -> DataStoreResult<Node> {
         info!("[dry-run] create_node: {}", node.name);
         Ok(node.clone())
     }
-    async fn get_node(&self, id: &Uuid) -> DataStoreResult<Option<Node>> { self.inner.get_node(id).await }
-    async fn list_nodes(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Node>> { self.inner.list_nodes(options).await }
+    async fn get_node(&self, id: &Uuid) -> DataStoreResult<Option<Node>> {
+        self.inner.get_node(id).await
+    }
+    async fn list_nodes(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Node>> {
+        self.inner.list_nodes(options).await
+    }
     async fn update_node(&self, node: &Node) -> DataStoreResult<Node> {
         info!("[dry-run] update_node: {}", node.name);
         Ok(node.clone())
@@ -37,16 +51,24 @@ impl DataStore for DryRunStore {
         info!("[dry-run] delete_node: {}", id);
         Ok(())
     }
-    async fn get_nodes_by_location(&self, location_id: &Uuid) -> DataStoreResult<Vec<Node>> { self.inner.get_nodes_by_location(location_id).await }
-    async fn search_nodes_by_name(&self, name: &str) -> DataStoreResult<Vec<Node>> { self.inner.search_nodes_by_name(name).await }
+    async fn get_nodes_by_location(&self, location_id: &Uuid) -> DataStoreResult<Vec<Node>> {
+        self.inner.get_nodes_by_location(location_id).await
+    }
+    async fn search_nodes_by_name(&self, name: &str) -> DataStoreResult<Vec<Node>> {
+        self.inner.search_nodes_by_name(name).await
+    }
 
     // Link ops
     async fn create_link(&self, link: &Link) -> DataStoreResult<Link> {
         info!("[dry-run] create_link: {}", link.name);
         Ok(link.clone())
     }
-    async fn get_link(&self, id: &Uuid) -> DataStoreResult<Option<Link>> { self.inner.get_link(id).await }
-    async fn list_links(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Link>> { self.inner.list_links(options).await }
+    async fn get_link(&self, id: &Uuid) -> DataStoreResult<Option<Link>> {
+        self.inner.get_link(id).await
+    }
+    async fn list_links(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Link>> {
+        self.inner.list_links(options).await
+    }
     async fn update_link(&self, link: &Link) -> DataStoreResult<Link> {
         info!("[dry-run] update_link: {}", link.name);
         Ok(link.clone())
@@ -55,16 +77,27 @@ impl DataStore for DryRunStore {
         info!("[dry-run] delete_link: {}", id);
         Ok(())
     }
-    async fn get_links_for_node(&self, node_id: &Uuid) -> DataStoreResult<Vec<Link>> { self.inner.get_links_for_node(node_id).await }
-    async fn get_links_between_nodes(&self, a: &Uuid, b: &Uuid) -> DataStoreResult<Vec<Link>> { self.inner.get_links_between_nodes(a, b).await }
+    async fn get_links_for_node(&self, node_id: &Uuid) -> DataStoreResult<Vec<Link>> {
+        self.inner.get_links_for_node(node_id).await
+    }
+    async fn get_links_between_nodes(&self, a: &Uuid, b: &Uuid) -> DataStoreResult<Vec<Link>> {
+        self.inner.get_links_between_nodes(a, b).await
+    }
 
     // Location ops
     async fn create_location(&self, location: &Location) -> DataStoreResult<Location> {
         info!("[dry-run] create_location: {}", location.name);
         Ok(location.clone())
     }
-    async fn get_location(&self, id: &Uuid) -> DataStoreResult<Option<Location>> { self.inner.get_location(id).await }
-    async fn list_locations(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Location>> { self.inner.list_locations(options).await }
+    async fn get_location(&self, id: &Uuid) -> DataStoreResult<Option<Location>> {
+        self.inner.get_location(id).await
+    }
+    async fn list_locations(
+        &self,
+        options: &QueryOptions,
+    ) -> DataStoreResult<PagedResult<Location>> {
+        self.inner.list_locations(options).await
+    }
     async fn update_location(&self, location: &Location) -> DataStoreResult<Location> {
         info!("[dry-run] update_location: {}", location.name);
         Ok(location.clone())
@@ -79,54 +112,133 @@ impl DataStore for DryRunStore {
         info!("[dry-run] create_vendor: {}", name);
         Ok(())
     }
-    async fn list_vendors(&self) -> DataStoreResult<Vec<String>> { self.inner.list_vendors().await }
+    async fn list_vendors(&self) -> DataStoreResult<Vec<String>> {
+        self.inner.list_vendors().await
+    }
     async fn delete_vendor(&self, name: &str) -> DataStoreResult<()> {
         info!("[dry-run] delete_vendor: {}", name);
         Ok(())
     }
 
     // Batch
-    async fn batch_nodes(&self, operations: &[BatchOperation<Node>]) -> DataStoreResult<BatchResult> {
+    async fn batch_nodes(
+        &self,
+        operations: &[BatchOperation<Node>],
+    ) -> DataStoreResult<BatchResult> {
         info!("[dry-run] batch_nodes: {} ops", operations.len());
-        Ok(BatchResult { success_count: operations.len(), error_count: 0, errors: vec![] })
+        Ok(BatchResult {
+            success_count: operations.len(),
+            error_count: 0,
+            errors: vec![],
+        })
     }
-    async fn batch_links(&self, operations: &[BatchOperation<Link>]) -> DataStoreResult<BatchResult> {
+    async fn batch_links(
+        &self,
+        operations: &[BatchOperation<Link>],
+    ) -> DataStoreResult<BatchResult> {
         info!("[dry-run] batch_links: {} ops", operations.len());
-        Ok(BatchResult { success_count: operations.len(), error_count: 0, errors: vec![] })
+        Ok(BatchResult {
+            success_count: operations.len(),
+            error_count: 0,
+            errors: vec![],
+        })
     }
-    async fn batch_locations(&self, operations: &[BatchOperation<Location>]) -> DataStoreResult<BatchResult> {
+    async fn batch_locations(
+        &self,
+        operations: &[BatchOperation<Location>],
+    ) -> DataStoreResult<BatchResult> {
         info!("[dry-run] batch_locations: {} ops", operations.len());
-        Ok(BatchResult { success_count: operations.len(), error_count: 0, errors: vec![] })
+        Ok(BatchResult {
+            success_count: operations.len(),
+            error_count: 0,
+            errors: vec![],
+        })
     }
 
     // Stats
-    async fn get_entity_counts(&self) -> DataStoreResult<std::collections::HashMap<String, usize>> { self.inner.get_entity_counts().await }
-    async fn get_statistics(&self) -> DataStoreResult<std::collections::HashMap<String, serde_json::Value>> { self.inner.get_statistics().await }
+    async fn get_entity_counts(&self) -> DataStoreResult<std::collections::HashMap<String, usize>> {
+        self.inner.get_entity_counts().await
+    }
+    async fn get_statistics(
+        &self,
+    ) -> DataStoreResult<std::collections::HashMap<String, serde_json::Value>> {
+        self.inner.get_statistics().await
+    }
 
     // Derived state
-    async fn get_node_status(&self, node_id: &Uuid) -> DataStoreResult<Option<unet_core::models::derived::NodeStatus>> { self.inner.get_node_status(node_id).await }
-    async fn get_node_interfaces(&self, node_id: &Uuid) -> DataStoreResult<Vec<unet_core::models::derived::InterfaceStatus>> { self.inner.get_node_interfaces(node_id).await }
-    async fn get_node_metrics(&self, node_id: &Uuid) -> DataStoreResult<Option<unet_core::models::derived::PerformanceMetrics>> { self.inner.get_node_metrics(node_id).await }
+    async fn get_node_status(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Option<unet_core::models::derived::NodeStatus>> {
+        self.inner.get_node_status(node_id).await
+    }
+    async fn get_node_interfaces(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Vec<unet_core::models::derived::InterfaceStatus>> {
+        self.inner.get_node_interfaces(node_id).await
+    }
+    async fn get_node_metrics(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Option<unet_core::models::derived::PerformanceMetrics>> {
+        self.inner.get_node_metrics(node_id).await
+    }
 
     // Policy
-    async fn store_policy_result(&self, node_id: &Uuid, rule_id: &str, result: &PolicyExecutionResult) -> DataStoreResult<()> {
-        info!("[dry-run] store_policy_result: node={} rule={} result={:?}", node_id, rule_id, result);
+    async fn store_policy_result(
+        &self,
+        node_id: &Uuid,
+        rule_id: &str,
+        result: &PolicyExecutionResult,
+    ) -> DataStoreResult<()> {
+        info!(
+            "[dry-run] store_policy_result: node={} rule={} result={:?}",
+            node_id, rule_id, result
+        );
         Ok(())
     }
-    async fn get_policy_results(&self, node_id: &Uuid) -> DataStoreResult<Vec<PolicyExecutionResult>> { self.inner.get_policy_results(node_id).await }
-    async fn get_latest_policy_results(&self, node_id: &Uuid) -> DataStoreResult<Vec<PolicyExecutionResult>> { self.inner.get_latest_policy_results(node_id).await }
-    async fn get_rule_results(&self, rule_id: &str) -> DataStoreResult<Vec<(Uuid, PolicyExecutionResult)>> { self.inner.get_rule_results(rule_id).await }
+    async fn get_policy_results(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Vec<PolicyExecutionResult>> {
+        self.inner.get_policy_results(node_id).await
+    }
+    async fn get_latest_policy_results(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Vec<PolicyExecutionResult>> {
+        self.inner.get_latest_policy_results(node_id).await
+    }
+    async fn get_rule_results(
+        &self,
+        rule_id: &str,
+    ) -> DataStoreResult<Vec<(Uuid, PolicyExecutionResult)>> {
+        self.inner.get_rule_results(rule_id).await
+    }
 
-    async fn update_node_custom_data(&self, node_id: &Uuid, custom_data: &serde_json::Value) -> DataStoreResult<()> {
-        info!("[dry-run] update_node_custom_data: {} -> {}", node_id, custom_data);
+    async fn update_node_custom_data(
+        &self,
+        node_id: &Uuid,
+        custom_data: &serde_json::Value,
+    ) -> DataStoreResult<()> {
+        info!(
+            "[dry-run] update_node_custom_data: {} -> {}",
+            node_id, custom_data
+        );
         // Optionally verify node exists
         if self.inner.get_node(node_id).await?.is_none() {
-            return Err(DataStoreError::NotFound { entity_type: "Node".into(), id: node_id.to_string() });
+            return Err(DataStoreError::NotFound {
+                entity_type: "Node".into(),
+                id: node_id.to_string(),
+            });
         }
         Ok(())
     }
 
-    async fn get_nodes_for_policy_evaluation(&self) -> DataStoreResult<Vec<Node>> { self.inner.get_nodes_for_policy_evaluation().await }
+    async fn get_nodes_for_policy_evaluation(&self) -> DataStoreResult<Vec<Node>> {
+        self.inner.get_nodes_for_policy_evaluation().await
+    }
 }
 
 #[cfg(test)]
@@ -138,8 +250,13 @@ mod tests {
     #[tokio::test]
     async fn test_dry_run_create_update_delete_node_ok() {
         let node = NodeBuilder::new()
-            .name("n1").domain("example.com").vendor(Vendor::Cisco).model("ISR").role(DeviceRole::Router)
-            .build().unwrap();
+            .name("n1")
+            .domain("example.com")
+            .vendor(Vendor::Cisco)
+            .model("ISR")
+            .role(DeviceRole::Router)
+            .build()
+            .unwrap();
         let mock = MockDataStore::new();
         let store = DryRunStore::new(Arc::new(mock));
         let created = store.create_node(&node).await.unwrap();

--- a/crates/unet-cli/src/runtime.rs
+++ b/crates/unet-cli/src/runtime.rs
@@ -24,8 +24,8 @@ pub struct SeaOrmConnector;
 #[allow(clippy::module_name_repetitions)]
 impl DbConnector for SeaOrmConnector {
     fn connect(&self, url: &str) -> Pin<Box<dyn Future<Output = Result<Db>> + Send>> {
-        use sea_orm::Database;
         use sea_orm::ConnectOptions;
+        use sea_orm::Database;
         let url = url.to_owned();
         Box::pin(async move {
             let mut opt = ConnectOptions::new(&url);
@@ -91,7 +91,7 @@ mod tests {
     impl DbConnector for NoopConnector {
         fn connect(&self, _url: &str) -> Pin<Box<dyn Future<Output = Result<Db>> + Send>> {
             // Return an error-free placeholder by connecting to in-memory SQLite
-            use sea_orm::{Database, ConnectOptions};
+            use sea_orm::{ConnectOptions, Database};
             Box::pin(async move {
                 let mut opt = ConnectOptions::new("sqlite::memory:");
                 opt.sqlx_logging(false);

--- a/crates/unet-core/src/policy/evaluator/results.rs
+++ b/crates/unet-core/src/policy/evaluator/results.rs
@@ -10,9 +10,18 @@ use uuid::Uuid;
 
 /// Priority level for policy rules
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    Default,
 )]
-#[derive(Default)]
 pub enum PolicyPriority {
     /// Low priority execution
     Low = 0,
@@ -24,7 +33,6 @@ pub enum PolicyPriority {
     /// Critical priority execution (highest)
     Critical = 3,
 }
-
 
 impl std::fmt::Display for PolicyPriority {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/unet-core/tests/sqlite_datastore.rs
+++ b/crates/unet-core/tests/sqlite_datastore.rs
@@ -109,7 +109,10 @@ async fn vendor_duplicate_insertion_errors() {
     // First insert succeeds
     store.create_vendor("DupCorp").await.expect("add vendor");
     // Second insert should error
-    let err = store.create_vendor("DupCorp").await.expect_err("expected error on duplicate");
+    let err = store
+        .create_vendor("DupCorp")
+        .await
+        .expect_err("expected error on duplicate");
     // Ensure error message path covered
     let msg = format!("{err}");
     assert!(msg.to_lowercase().contains("insert") || msg.to_lowercase().contains("failed"));
@@ -120,7 +123,10 @@ async fn vendor_duplicate_insertion_errors() {
 async fn get_node_required_not_found() {
     let store = sqlite_store().await;
     let missing = uuid::Uuid::new_v4();
-    let err = store.get_node_required(&missing).await.expect_err("expected not found");
+    let err = store
+        .get_node_required(&missing)
+        .await
+        .expect_err("expected not found");
     let msg = format!("{err}");
     assert!(msg.to_lowercase().contains("not found") || msg.to_lowercase().contains("node"));
 }
@@ -129,7 +135,10 @@ async fn get_node_required_not_found() {
 #[tokio::test]
 async fn delete_vendor_nonexistent_errors() {
     let store = sqlite_store().await;
-    let err = store.delete_vendor("does-not-exist").await.expect_err("expected not found");
+    let err = store
+        .delete_vendor("does-not-exist")
+        .await
+        .expect_err("expected not found");
     let msg = format!("{err}");
     assert!(msg.to_lowercase().contains("not found") || msg.to_lowercase().contains("vendor"));
 }

--- a/crates/unet-server/src/background/manager.rs
+++ b/crates/unet-server/src/background/manager.rs
@@ -52,7 +52,6 @@ mod tests {
     use unet_core::datastore::sqlite::SqliteStore;
 
     async fn setup_test_datastore() -> SqliteStore {
-        
         test_support::sqlite::sqlite_store().await
     }
 

--- a/crates/unet-server/src/background/policy_task/tests.rs
+++ b/crates/unet-server/src/background/policy_task/tests.rs
@@ -12,7 +12,6 @@ use unet_core::{
 };
 
 async fn setup_test_datastore() -> SqliteStore {
-    
     test_support::sqlite::sqlite_store().await
 }
 

--- a/crates/unet-server/src/handlers/health.rs
+++ b/crates/unet-server/src/handlers/health.rs
@@ -70,9 +70,9 @@ mod tests {
     use crate::server::AppState;
     use axum::{extract::State, http::StatusCode};
     use std::sync::Arc;
+    use test_support::sqlite::sqlite_store;
     use unet_core::datastore::sqlite::SqliteStore;
     use unet_core::policy_integration::PolicyService;
-    use test_support::sqlite::sqlite_store;
 
     async fn create_healthy_app_state() -> AppState {
         let git_config = unet_core::config::GitConfig {

--- a/crates/unet-server/src/handlers/policies/node_fetching.rs
+++ b/crates/unet-server/src/handlers/policies/node_fetching.rs
@@ -54,10 +54,12 @@ async fn get_all_nodes_for_evaluation(datastore: &dyn DataStore) -> Result<Vec<N
 #[cfg(test)]
 mod tests {
     use super::*;
-    use unet_core::{datastore::sqlite::SqliteStore, models::*};
     use test_support::sqlite::sqlite_store;
+    use unet_core::{datastore::sqlite::SqliteStore, models::*};
 
-    async fn setup_test_datastore() -> SqliteStore { sqlite_store().await }
+    async fn setup_test_datastore() -> SqliteStore {
+        sqlite_store().await
+    }
 
     async fn create_test_node(datastore: &SqliteStore) -> Node {
         let mut node = Node::new(

--- a/crates/unet-server/src/handlers/policies/policy_execution/test_helpers.rs
+++ b/crates/unet-server/src/handlers/policies/policy_execution/test_helpers.rs
@@ -6,7 +6,6 @@ use unet_core::{
 };
 
 pub async fn setup_test_datastore() -> SqliteStore {
-    
     test_support::sqlite::sqlite_store().await
 }
 

--- a/crates/unet-server/src/handlers/policies/response_handling.rs
+++ b/crates/unet-server/src/handlers/policies/response_handling.rs
@@ -95,15 +95,17 @@ mod tests {
     use std::fs;
     use std::sync::Arc;
     use tempfile::TempDir;
+    use test_support::sqlite::sqlite_store;
     use unet_core::{
         datastore::{DataStore, sqlite::SqliteStore},
         models::*,
         policy::{Action, ComparisonOperator, Condition, FieldRef, PolicyRule, Value},
         policy_integration::PolicyService,
     };
-    use test_support::sqlite::sqlite_store;
 
-    async fn setup_test_datastore() -> SqliteStore { sqlite_store().await }
+    async fn setup_test_datastore() -> SqliteStore {
+        sqlite_store().await
+    }
 
     async fn create_test_node(datastore: &SqliteStore) -> Node {
         let mut node = Node::new(
@@ -185,7 +187,8 @@ WHEN node.vendor == "cisco" THEN ASSERT node.version IS "15.1"
 
             let response = result.unwrap().0;
             assert_eq!(response.nodes_evaluated, 1);
-        }).await;
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -335,7 +338,8 @@ WHEN node.vendor == "cisco" THEN ASSERT node.version IS "15.1"
 
             let response = result.unwrap().0;
             assert_eq!(response.nodes_evaluated, 1);
-        }).await;
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/crates/unet-server/src/handlers/policies/validation.rs
+++ b/crates/unet-server/src/handlers/policies/validation.rs
@@ -56,14 +56,16 @@ mod tests {
     use super::*;
     use crate::server::AppState;
     use std::sync::Arc;
+    use test_support::sqlite::sqlite_store;
     use unet_core::{
         datastore::sqlite::SqliteStore,
         policy::{Action, ComparisonOperator, Condition, FieldRef, PolicyRule, Value},
         policy_integration::PolicyService,
     };
-    use test_support::sqlite::sqlite_store;
 
-    async fn setup_test_datastore() -> SqliteStore { sqlite_store().await }
+    async fn setup_test_datastore() -> SqliteStore {
+        sqlite_store().await
+    }
 
     fn create_test_policy_rule() -> PolicyRule {
         PolicyRule {

--- a/crates/unet-server/src/lib.rs
+++ b/crates/unet-server/src/lib.rs
@@ -8,4 +8,3 @@ pub mod handlers;
 pub mod server;
 
 pub use server::run;
-

--- a/docs/archive/10_future_work.md
+++ b/docs/archive/10_future_work.md
@@ -139,7 +139,7 @@
 | ----------------- | ------------- | --------------- | ------------- | ------------------------------ |
 | Rust async/Axum   | @alice        | @mentor\_dev    | Yes (mid)     | Critical path for poller split |
 | SNMP/Vendor RPC   | @bob          | –               | No            | Could outsource driver stubs   |
-| Postgres tuning   | –             | external SME    | Yes (consult) | For RLS & partitioning         |
+| Postgres tuning   | –             | external advisor | Yes (consult) | For RLS & partitioning         |
 | Front‑end (Tauri) | @carol        | –               | No            | Junior can shadow              |
 | DevOps/Nix        | –             | @mentor\_dev    | Maybe         | Flake packaging upkeep         |
 

--- a/docs/setup-pre-commit.md
+++ b/docs/setup-pre-commit.md
@@ -1,6 +1,6 @@
 # Setting Up Pre-commit Hooks
 
-μNet uses mise for pre-commit hooks instead of the traditional pre-commit framework. This ensures **perfect consistency** between local development and CI environments.
+μNet uses `mise` for pre-commit hooks instead of the traditional `pre-commit` framework. Local hooks and CI share the same task definitions, but they now use separate read-only and autofix tasks.
 
 ## Quick Setup
 
@@ -12,28 +12,26 @@ chmod +x .git/hooks/pre-commit
 
 ## What the Pre-commit Hook Does
 
-When you run `git commit`, it automatically executes `mise run pre-commit` which runs the **exact same `lint` task** used in CI:
+When you run `git commit`, it automatically executes `mise run pre-commit`, which depends on `lint-fix` for local autofix behavior:
 
 1. **Fixes typos** with `typos -w`
 2. **Formats code** with `cargo fmt`  
-3. **Runs clippy** with `--allow-dirty --fix` (auto-fixes issues when possible)
+3. **Runs clippy** with `--allow-dirty --fix`
 
-## Benefits
-
-✅ **Zero duplication** - same task as CI uses  
-✅ **Auto-fixes** code issues when possible  
-✅ **Fast feedback** - catch issues before pushing  
-✅ **Consistent** - identical behavior locally and in CI
+CI continues to use the separate read-only `mise run ci-lint` task, which depends on `mise run lint`.
 
 ## Manual Tasks
 
-You can also run the same checks manually:
+You can run the local autofix path or the read-only CI path directly:
 
 ```bash
-# Run the same checks as pre-commit hook
+# Run the same autofix task as the pre-commit hook
 mise run pre-commit
 
-# Or run lint directly (same thing)
+# Or run the autofix task directly
+mise run lint-fix
+
+# Run the read-only checks used by CI and `status`
 mise run lint
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -13,8 +13,16 @@ typos = "latest"
 "npm:markdownlint-cli2" = "latest"
 
 [tasks.lint]
-description = "Fix code issues and run linters"
+description = "Run read-only linting and formatting checks"
+run = ["typos", "cargo fmt --check", "cargo clippy --workspace"]
+
+[tasks.lint-fix]
+description = "Auto-fix typos and Rust formatting/lint issues"
 run = ["typos -w", "cargo fmt", "cargo clippy --workspace --allow-dirty --fix"]
+
+[tasks.check-read-only-tasks]
+description = "Validate that `status` and CI lint tasks stay read-only by default"
+run = ["bash scripts/check-read-only-tasks.sh"]
 
 [tasks.test]
 description = "Run unit tests"
@@ -58,7 +66,7 @@ run = [
 
 [tasks.ci-lint]
 description = "Run linting and formatting checks for CI"
-depends = ["lint"]
+depends = ["check-read-only-tasks", "lint"]
 
 [tasks.ci-test]
 description = "Run unit tests for CI"
@@ -89,7 +97,7 @@ run = ["cargo doc --workspace --no-deps --document-private-items"]
 
 [tasks.pre-commit]
 description = "Pre-commit checks"
-depends = ["lint"]
+depends = ["lint-fix"]
 
 [tasks.status]
 description = "LLM-friendly project status overview (clippy + coverage tests + summaries)"

--- a/scripts/check-read-only-tasks.sh
+++ b/scripts/check-read-only-tasks.sh
@@ -26,10 +26,18 @@ assert_file_contains() {
   local file_path=$1
   local expected_text=$2
 
-  if ! rg -Fq -- "$expected_text" "$file_path"; then
+  if command -v rg >/dev/null 2>&1; then
+    if rg -Fq -- "$expected_text" "$file_path"; then
+      return 0
+    fi
+  elif grep -Fq -- "$expected_text" "$file_path"; then
+    return 0
+  fi
+
+  {
     printf 'expected %s to contain: %s\n' "$file_path" "$expected_text" >&2
     exit 1
-  fi
+  }
 }
 
 lint_block=$(extract_task_block "lint")

--- a/scripts/check-read-only-tasks.sh
+++ b/scripts/check-read-only-tasks.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+extract_task_block() {
+  local task_name=$1
+
+  awk -v task_name="$task_name" '
+    $0 == "[tasks." task_name "]" { in_block = 1; next }
+    /^\[tasks\./ && in_block { exit }
+    in_block { print }
+  ' mise.toml
+}
+
+assert_block_contains() {
+  local block_name=$1
+  local expected_line=$2
+  local block_content=$3
+
+  if ! grep -Fqx "$expected_line" <<<"$block_content"; then
+    printf 'expected %s to contain exact line: %s\n' "$block_name" "$expected_line" >&2
+    exit 1
+  fi
+}
+
+assert_file_contains() {
+  local file_path=$1
+  local expected_text=$2
+
+  if ! rg -Fq -- "$expected_text" "$file_path"; then
+    printf 'expected %s to contain: %s\n' "$file_path" "$expected_text" >&2
+    exit 1
+  fi
+}
+
+lint_block=$(extract_task_block "lint")
+assert_block_contains "tasks.lint" 'description = "Run read-only linting and formatting checks"' "$lint_block"
+assert_block_contains "tasks.lint" 'run = ["typos", "cargo fmt --check", "cargo clippy --workspace"]' "$lint_block"
+
+lint_fix_block=$(extract_task_block "lint-fix")
+assert_block_contains "tasks.lint-fix" 'description = "Auto-fix typos and Rust formatting/lint issues"' "$lint_fix_block"
+assert_block_contains "tasks.lint-fix" 'run = ["typos -w", "cargo fmt", "cargo clippy --workspace --allow-dirty --fix"]' "$lint_fix_block"
+
+ci_lint_block=$(extract_task_block "ci-lint")
+assert_block_contains "tasks.ci-lint" 'depends = ["check-read-only-tasks", "lint"]' "$ci_lint_block"
+
+pre_commit_block=$(extract_task_block "pre-commit")
+assert_block_contains "tasks.pre-commit" 'depends = ["lint-fix"]' "$pre_commit_block"
+
+assert_file_contains "scripts/status-llm.sh" 'CLIPPY_FIX_DEFAULT=0'
+assert_file_contains "scripts/status-llm.sh" 'STATUS_CLIPPY_FIX'

--- a/scripts/status-llm.sh
+++ b/scripts/status-llm.sh
@@ -20,14 +20,14 @@ echo "[status]  - Failures exact: rg -n '(?i)^(failures:|.*\\bFAILED\\b)|panicke
 echo "[status]  - Coverage total: rg -n '^TOTAL' ${run_dir}/coverage.log"
 echo "[status]  - Missing lines:  rg -n '^[^ ]+\\.rs:' ${run_dir}/coverage.log"
 
-# 1) Clippy (non-invasive: no --fix, no formatting)
+# 1) Clippy (read-only by default; auto-fix is opt-in)
 phase_start=${SECONDS}
-CLIPPY_FIX_DEFAULT=1
+CLIPPY_FIX_DEFAULT=0
 CLIPPY_FIX=${STATUS_CLIPPY_FIX:-$CLIPPY_FIX_DEFAULT}
 if [[ "$CLIPPY_FIX" == "1" ]]; then
-  echo "[status] Running clippy with auto-fix (allow-dirty)"
+  echo "[status] Running clippy with auto-fix (STATUS_CLIPPY_FIX=1)"
 else
-  echo "[status] Running clippy (no auto-fix)"
+  echo "[status] Running clippy (read-only; set STATUS_CLIPPY_FIX=1 to auto-fix)"
 fi
 set -o pipefail
 set +e


### PR DESCRIPTION
## Summary
- split `mise` linting into read-only `lint` and explicit `lint-fix`
- make `status` clippy read-only by default and add a regression script for the task wiring
- run the explicit autofix path on the latest `origin/master` base and add a targeted nextest timeout override so `status` completes under `llvm-cov`

## Testing
- `bash scripts/check-read-only-tasks.sh`
- `timeout 900 mise run lint-fix`
- `timeout 300 mise run ci-lint`
- `mise run check-large-files`
- `timeout 1200 mise run status`
