### PR TITLE
Implement local node polling task controls

### DIFF
--- a/crates/unet-cli/src/commands/nodes/advanced_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/advanced_tests.rs
@@ -67,19 +67,17 @@ mod integration_tests {
             PollingAction::Start,
             PollingAction::Stop,
             PollingAction::Restart,
-            PollingAction::History,
         ];
 
         // Test that all polling actions are properly constructed
-        assert_eq!(polling_actions.len(), 5);
+        assert_eq!(polling_actions.len(), 4);
         // Verify all variants can be matched
         for polling_action in polling_actions {
             match polling_action {
                 PollingAction::Status
                 | PollingAction::Start
                 | PollingAction::Stop
-                | PollingAction::Restart
-                | PollingAction::History => {}
+                | PollingAction::Restart => {}
             }
         }
 

--- a/crates/unet-cli/src/commands/nodes/dispatch_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/dispatch_tests.rs
@@ -47,6 +47,9 @@ mod tests {
             )))
         });
         store
+            .expect_get_node_polling_task()
+            .returning(|_| ready_ok(None));
+        store
             .expect_get_node_interfaces()
             .returning(|_| ready_ok(Vec::<unet_core::models::derived::InterfaceStatus>::new()));
         store

--- a/crates/unet-cli/src/commands/nodes/monitoring.rs
+++ b/crates/unet-cli/src/commands/nodes/monitoring.rs
@@ -2,6 +2,7 @@
 use anyhow::Result;
 use unet_core::datastore::DataStore;
 
+use super::polling::polling_status_value;
 use super::types::{MetricsNodeArgs, StatusNodeArgs, StatusType};
 
 pub async fn status_node(
@@ -60,13 +61,16 @@ pub async fn status_node(
                     });
                 }
             },
-            StatusType::Polling => {
-                // TODO: Add polling task status when implemented
-                output["polling"] = serde_json::json!({
-                    "message": "Polling task status display not yet implemented",
-                    "note": "This will show SNMP polling task status for the node"
-                });
-            }
+            StatusType::Polling => match datastore.get_node_polling_task(&args.id).await {
+                Ok(task) => {
+                    output["polling"] = polling_status_value(task.as_ref(), false);
+                }
+                Err(e) => {
+                    output["polling"] = serde_json::json!({
+                        "error": format!("Failed to fetch polling task: {}", e)
+                    });
+                }
+            },
         }
     }
 

--- a/crates/unet-cli/src/commands/nodes/monitoring_exec_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/monitoring_exec_tests.rs
@@ -5,12 +5,15 @@ mod tests {
     use crate::commands::nodes::monitoring::{metrics_node, status_node};
     use crate::commands::nodes::types::{MetricsNodeArgs, StatusNodeArgs, StatusType};
     use mockall::predicate::eq;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::time::Duration;
     use unet_core::datastore::{DataStoreError, MockDataStore};
     use unet_core::models::derived::{
         InterfaceAdminStatus, InterfaceOperStatus, InterfaceStats, InterfaceStatus, NodeStatus,
         PerformanceMetrics,
     };
     use unet_core::models::{DeviceRole, NodeBuilder, Vendor};
+    use unet_core::snmp::{PollingTask, SessionConfig};
     use uuid::Uuid;
 
     fn make_node() -> unet_core::models::Node {
@@ -188,6 +191,40 @@ mod tests {
                 .await
                 .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn test_status_polling_fetches_saved_task() {
+        let node = make_node();
+        let id = node.id;
+        let polling_task = PollingTask::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 50)), 161),
+            id,
+            vec!["1.3.6.1.2.1.1.1.0".to_string()],
+            Duration::from_secs(300),
+            SessionConfig::default(),
+        );
+
+        let mut mock = MockDataStore::new();
+        mock.expect_get_node_required()
+            .with(eq(id))
+            .returning(move |_| {
+                let n = node.clone();
+                Box::pin(async move { Ok(n) })
+            });
+        mock.expect_get_node_polling_task()
+            .with(eq(id))
+            .returning(move |_| {
+                let task = polling_task.clone();
+                Box::pin(async move { Ok(Some(task)) })
+            });
+
+        let args = StatusNodeArgs {
+            id,
+            status_type: vec![StatusType::Polling],
+        };
+        let res = status_node(args, &mock, crate::OutputFormat::Json).await;
+        assert!(res.is_ok());
     }
 
     #[tokio::test]

--- a/crates/unet-cli/src/commands/nodes/polling.rs
+++ b/crates/unet-cli/src/commands/nodes/polling.rs
@@ -1,8 +1,51 @@
 /// Node polling operations
-use anyhow::Result;
+use anyhow::{Result, anyhow};
+use std::net::SocketAddr;
+use std::time::SystemTime;
+use unet_core::config::defaults;
 use unet_core::datastore::DataStore;
+use unet_core::models::Node;
+use unet_core::snmp::{PollingConfig, PollingTask, SessionConfig, StandardOid};
 
 use super::types::{PollingAction, PollingNodeArgs};
+
+pub(super) fn polling_status_value(
+    task: Option<&PollingTask>,
+    detailed: bool,
+) -> serde_json::Value {
+    task.map_or_else(
+        || {
+            serde_json::json!({
+                "state": "not_configured",
+                "enabled": false,
+                "message": "No polling task configured for this node"
+            })
+        },
+        |task| {
+            let mut output = serde_json::json!({
+                "state": if task.enabled { "enabled" } else { "disabled" },
+                "enabled": task.enabled,
+                "task_id": task.id.to_string(),
+                "target": task.target.to_string(),
+                "interval_seconds": task.interval.as_secs(),
+                "oid_count": task.oids.len(),
+                "priority": task.priority,
+                "created_at": format_timestamp(task.created_at),
+                "last_success": task.last_success.map(format_timestamp),
+                "last_error": task.last_error.clone(),
+                "consecutive_failures": task.consecutive_failures
+            });
+
+            if detailed {
+                output["oids"] = serde_json::json!(task.oids.clone());
+                output["session_config"] =
+                    serde_json::to_value(&task.session_config).unwrap_or(serde_json::Value::Null);
+            }
+
+            output
+        },
+    )
+}
 
 pub async fn polling_node(
     args: PollingNodeArgs,
@@ -14,45 +57,120 @@ pub async fn polling_node(
 
     let mut output = serde_json::json!({
         "node_id": args.id,
-        "node_name": node.name,
+        "node_name": node.name.clone(),
         "action": format!("{:?}", args.action),
         "detailed": args.detailed
     });
 
     match args.action {
         PollingAction::Status => {
-            output["status"] = serde_json::json!({
-                "message": "Polling status display not yet fully implemented",
-                "note": "This would show current SNMP polling task status"
-            });
+            let task = datastore.get_node_polling_task(&args.id).await?;
+            output["polling"] = polling_status_value(task.as_ref(), args.detailed);
         }
         PollingAction::Start => {
+            let task = enable_polling_task(datastore, &node, false).await?;
             output["result"] = serde_json::json!({
-                "message": "Polling start command not yet implemented",
-                "note": "This would start SNMP polling for the specified node"
+                "message": "Polling task enabled"
             });
+            output["polling"] = polling_status_value(Some(&task), args.detailed);
         }
         PollingAction::Stop => {
+            let task = disable_polling_task(datastore, &args.id).await?;
             output["result"] = serde_json::json!({
-                "message": "Polling stop command not yet implemented",
-                "note": "This would stop SNMP polling for the specified node"
+                "message": if task.is_some() {
+                    "Polling task disabled"
+                } else {
+                    "No polling task configured for this node"
+                }
             });
+            output["polling"] = polling_status_value(task.as_ref(), args.detailed);
         }
         PollingAction::Restart => {
+            let task = enable_polling_task(datastore, &node, true).await?;
             output["result"] = serde_json::json!({
-                "message": "Polling restart command not yet implemented",
-                "note": "This would restart SNMP polling for the specified node"
+                "message": "Polling task restarted"
             });
-        }
-        PollingAction::History => {
-            output["history"] = serde_json::json!({
-                "message": "Polling history display not yet implemented",
-                "note": "This would show polling task execution history"
-            });
+            output["polling"] = polling_status_value(Some(&task), args.detailed);
         }
     }
 
     crate::commands::print_output(&output, output_format)?;
 
     Ok(())
+}
+
+async fn enable_polling_task(
+    datastore: &dyn DataStore,
+    node: &Node,
+    reset_runtime_state: bool,
+) -> Result<PollingTask> {
+    let task = match datastore.get_node_polling_task(&node.id).await? {
+        Some(mut task) => {
+            refresh_task_target(&mut task, node);
+            task.enabled = true;
+            if reset_runtime_state {
+                task.last_error = None;
+                task.consecutive_failures = 0;
+            }
+            task
+        }
+        None => build_polling_task(node)?,
+    };
+
+    datastore
+        .upsert_polling_task(&task)
+        .await
+        .map_err(Into::into)
+}
+
+async fn disable_polling_task(
+    datastore: &dyn DataStore,
+    node_id: &uuid::Uuid,
+) -> Result<Option<PollingTask>> {
+    let Some(mut task) = datastore.get_node_polling_task(node_id).await? else {
+        return Ok(None);
+    };
+
+    task.enabled = false;
+    datastore
+        .upsert_polling_task(&task)
+        .await
+        .map(Some)
+        .map_err(Into::into)
+}
+
+fn build_polling_task(node: &Node) -> Result<PollingTask> {
+    let management_ip = node.management_ip.ok_or_else(|| {
+        anyhow!(
+            "Node '{}' has no management IP configured; cannot create a polling task",
+            node.name
+        )
+    })?;
+    let target = SocketAddr::new(management_ip, defaults::network::SNMP_DEFAULT_PORT);
+    let session_config = SessionConfig {
+        address: target,
+        ..SessionConfig::default()
+    };
+
+    Ok(PollingTask::new(
+        target,
+        node.id,
+        StandardOid::system_oids()
+            .into_iter()
+            .map(|oid| oid.oid().to_string())
+            .collect(),
+        PollingConfig::default().default_interval,
+        session_config,
+    ))
+}
+
+const fn refresh_task_target(task: &mut PollingTask, node: &Node) {
+    if let Some(management_ip) = node.management_ip {
+        task.target = SocketAddr::new(management_ip, defaults::network::SNMP_DEFAULT_PORT);
+        task.session_config.address = task.target;
+    }
+}
+
+fn format_timestamp(value: SystemTime) -> String {
+    chrono::DateTime::<chrono::Utc>::from(value).to_rfc3339()
 }

--- a/crates/unet-cli/src/commands/nodes/polling_exec_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/polling_exec_tests.rs
@@ -1,53 +1,195 @@
 /// Execution tests for node polling command
 #[cfg(test)]
 mod tests {
-    use super::super::polling::polling_node;
+    use super::super::polling::{polling_node, polling_status_value};
     use super::super::types::{PollingAction, PollingNodeArgs};
-    use unet_core::datastore::{MockDataStore, testing::ready_ok};
+    use crate::OutputFormat;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::time::Duration;
+    use unet_core::datastore::DataStore;
+    use unet_core::snmp::{PollingTask, SessionConfig};
     use uuid::Uuid;
-
-    fn store_with_node(node: unet_core::models::Node) -> MockDataStore {
-        let mut store = MockDataStore::new();
-        store
-            .expect_get_node_required()
-            .returning(move |_| ready_ok(node.clone()));
-        store
-    }
 
     fn make_node() -> unet_core::models::Node {
         use unet_core::models::*;
-        let id = Uuid::new_v4();
         NodeBuilder::new()
-            .id(id)
+            .id(Uuid::new_v4())
             .name("edge-1")
             .domain("example.com")
             .vendor(Vendor::Cisco)
             .model("ISR4321")
             .role(DeviceRole::Router)
             .lifecycle(Lifecycle::Live)
+            .management_ip(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 20)))
             .build()
             .unwrap()
     }
 
     #[tokio::test]
-    async fn test_polling_actions_all_variants() {
-        let node = make_node();
-        let store = store_with_node(node.clone());
+    async fn test_polling_start_creates_persisted_task() {
+        test_support::sqlite::with_savepoint(
+            "polling_start_creates_persisted_task",
+            |store| async move {
+                let node = make_node();
+                store.create_node(&node).await.unwrap();
 
-        for action in [
-            PollingAction::Status,
-            PollingAction::Start,
-            PollingAction::Stop,
-            PollingAction::Restart,
-            PollingAction::History,
-        ] {
-            let args = PollingNodeArgs {
-                id: node.id,
-                action: action.clone(),
-                detailed: true,
-            };
-            let result = polling_node(args, &store, crate::OutputFormat::Json).await;
-            assert!(result.is_ok());
-        }
+                let args = PollingNodeArgs {
+                    id: node.id,
+                    action: PollingAction::Start,
+                    detailed: false,
+                };
+
+                let result = polling_node(args, &store, OutputFormat::Json).await;
+                assert!(result.is_ok());
+
+                let task = unet_core::entities::polling_tasks::Entity::find()
+                    .filter(
+                        unet_core::entities::polling_tasks::Column::NodeId.eq(node.id.to_string()),
+                    )
+                    .one(store.connection())
+                    .await
+                    .unwrap();
+
+                assert!(task.is_some());
+                assert!(task.unwrap().enabled);
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_polling_stop_disables_existing_task() {
+        test_support::sqlite::with_savepoint(
+            "polling_stop_disables_existing_task",
+            |store| async move {
+                let node = make_node();
+                store.create_node(&node).await.unwrap();
+
+                polling_node(
+                    PollingNodeArgs {
+                        id: node.id,
+                        action: PollingAction::Start,
+                        detailed: false,
+                    },
+                    &store,
+                    OutputFormat::Json,
+                )
+                .await
+                .unwrap();
+
+                polling_node(
+                    PollingNodeArgs {
+                        id: node.id,
+                        action: PollingAction::Stop,
+                        detailed: false,
+                    },
+                    &store,
+                    OutputFormat::Json,
+                )
+                .await
+                .unwrap();
+
+                let task = unet_core::entities::polling_tasks::Entity::find()
+                    .filter(
+                        unet_core::entities::polling_tasks::Column::NodeId.eq(node.id.to_string()),
+                    )
+                    .one(store.connection())
+                    .await
+                    .unwrap()
+                    .unwrap();
+
+                assert!(!task.enabled);
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_polling_restart_reenables_existing_task() {
+        test_support::sqlite::with_savepoint(
+            "polling_restart_reenables_existing_task",
+            |store| async move {
+                let node = make_node();
+                store.create_node(&node).await.unwrap();
+
+                polling_node(
+                    PollingNodeArgs {
+                        id: node.id,
+                        action: PollingAction::Start,
+                        detailed: false,
+                    },
+                    &store,
+                    OutputFormat::Json,
+                )
+                .await
+                .unwrap();
+
+                polling_node(
+                    PollingNodeArgs {
+                        id: node.id,
+                        action: PollingAction::Stop,
+                        detailed: false,
+                    },
+                    &store,
+                    OutputFormat::Json,
+                )
+                .await
+                .unwrap();
+
+                polling_node(
+                    PollingNodeArgs {
+                        id: node.id,
+                        action: PollingAction::Restart,
+                        detailed: false,
+                    },
+                    &store,
+                    OutputFormat::Json,
+                )
+                .await
+                .unwrap();
+
+                let task = unet_core::entities::polling_tasks::Entity::find()
+                    .filter(
+                        unet_core::entities::polling_tasks::Column::NodeId.eq(node.id.to_string()),
+                    )
+                    .one(store.connection())
+                    .await
+                    .unwrap()
+                    .unwrap();
+
+                assert!(task.enabled);
+            },
+        )
+        .await;
+    }
+
+    #[test]
+    fn test_polling_status_value_reports_missing_task() {
+        let status = polling_status_value(None, false);
+
+        assert_eq!(status["state"], "not_configured");
+        assert_eq!(status["enabled"], false);
+        assert!(status.get("oids").is_none());
+    }
+
+    #[test]
+    fn test_polling_status_value_reports_enabled_task() {
+        let task = PollingTask::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 20)), 161),
+            Uuid::new_v4(),
+            vec!["1.3.6.1.2.1.1.1.0".to_string()],
+            Duration::from_secs(300),
+            SessionConfig::default(),
+        );
+
+        let status = polling_status_value(Some(&task), true);
+
+        assert_eq!(status["state"], "enabled");
+        assert_eq!(status["enabled"], true);
+        assert_eq!(status["target"], "192.0.2.20:161");
+        assert_eq!(status["oid_count"], 1);
+        assert_eq!(status["interval_seconds"], 300);
+        assert_eq!(status["oids"][0], "1.3.6.1.2.1.1.1.0");
     }
 }

--- a/crates/unet-cli/src/commands/nodes/polling_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/polling_tests.rs
@@ -25,7 +25,6 @@ mod tests {
         assert!(matches!(PollingAction::Start, PollingAction::Start));
         assert!(matches!(PollingAction::Stop, PollingAction::Stop));
         assert!(matches!(PollingAction::Restart, PollingAction::Restart));
-        assert!(matches!(PollingAction::History, PollingAction::History));
     }
 
     #[tokio::test]
@@ -71,21 +70,6 @@ mod tests {
         assert_eq!(args.id, node_id);
         assert!(matches!(args.action, PollingAction::Restart));
         assert!(args.detailed);
-    }
-
-    #[tokio::test]
-    async fn test_polling_node_history_action() {
-        let node_id = Uuid::new_v4();
-
-        let args = PollingNodeArgs {
-            id: node_id,
-            action: PollingAction::History,
-            detailed: false,
-        };
-
-        assert_eq!(args.id, node_id);
-        assert!(matches!(args.action, PollingAction::History));
-        assert!(!args.detailed);
     }
 
     #[tokio::test]

--- a/crates/unet-cli/src/commands/nodes/types.rs
+++ b/crates/unet-cli/src/commands/nodes/types.rs
@@ -253,8 +253,6 @@ pub enum PollingAction {
     Stop,
     /// Restart polling for this node
     Restart,
-    /// Show polling task history
-    History,
 }
 
 #[derive(Args)]

--- a/crates/unet-core/src/datastore/mod.rs
+++ b/crates/unet-core/src/datastore/mod.rs
@@ -295,6 +295,26 @@ pub trait DataStore: Send + Sync {
         })
     }
 
+    /// Gets the persisted polling task for a specific node.
+    async fn get_node_polling_task(
+        &self,
+        _node_id: &Uuid,
+    ) -> DataStoreResult<Option<crate::snmp::PollingTask>> {
+        Err(DataStoreError::UnsupportedOperation {
+            operation: "get_node_polling_task".to_string(),
+        })
+    }
+
+    /// Creates or updates a persisted polling task.
+    async fn upsert_polling_task(
+        &self,
+        _task: &crate::snmp::PollingTask,
+    ) -> DataStoreResult<crate::snmp::PollingTask> {
+        Err(DataStoreError::UnsupportedOperation {
+            operation: "upsert_polling_task".to_string(),
+        })
+    }
+
     // Policy-related operations
     /// Stores a policy execution result
     async fn store_policy_result(

--- a/crates/unet-core/src/datastore/sqlite/mod.rs
+++ b/crates/unet-core/src/datastore/sqlite/mod.rs
@@ -10,6 +10,7 @@ mod links;
 mod locations;
 mod metadata;
 mod nodes;
+mod polling_tasks;
 mod store;
 mod transaction;
 mod vendors;

--- a/crates/unet-core/src/datastore/sqlite/polling_tasks.rs
+++ b/crates/unet-core/src/datastore/sqlite/polling_tasks.rs
@@ -1,0 +1,171 @@
+//! Polling-task persistence for the `SQLite` datastore
+
+use super::super::types::{DataStoreError, DataStoreResult};
+use super::SqliteStore;
+use crate::config::network;
+use crate::entities::polling_tasks;
+use crate::snmp::PollingTask;
+use chrono::{DateTime, Utc};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use serde::{Serialize, de::DeserializeOwned};
+use std::time::{Duration, SystemTime};
+use uuid::Uuid;
+
+pub async fn get_node_polling_task(
+    store: &SqliteStore,
+    node_id: &Uuid,
+) -> DataStoreResult<Option<PollingTask>> {
+    polling_tasks::Entity::find()
+        .filter(polling_tasks::Column::NodeId.eq(node_id.to_string()))
+        .one(&store.db)
+        .await
+        .map_err(|e| DataStoreError::InternalError {
+            message: format!("Failed to query polling task for node {node_id}: {e}"),
+        })?
+        .map(entity_to_polling_task)
+        .transpose()
+}
+
+pub async fn upsert_polling_task(
+    store: &SqliteStore,
+    task: &PollingTask,
+) -> DataStoreResult<PollingTask> {
+    let active_model = polling_tasks::ActiveModel {
+        id: Set(task.id.to_string()),
+        node_id: Set(task.node_id.to_string()),
+        target: Set(task.target.to_string()),
+        oids: Set(serialize_json(&task.oids, "polling_tasks.oids")?),
+        interval_seconds: Set(i64::try_from(task.interval.as_secs()).map_err(|e| {
+            DataStoreError::ValidationError {
+                message: format!("Invalid polling interval: {e}"),
+            }
+        })?),
+        session_config: Set(serialize_json(
+            &task.session_config,
+            "polling_tasks.session_config",
+        )?),
+        priority: Set(i16::from(task.priority)),
+        enabled: Set(task.enabled),
+        created_at: Set(format_timestamp(task.created_at)),
+        last_success: Set(task.last_success.map(format_timestamp)),
+        last_error: Set(task.last_error.clone()),
+        consecutive_failures: Set(i32::try_from(task.consecutive_failures).map_err(|e| {
+            DataStoreError::ValidationError {
+                message: format!("Invalid consecutive failures count: {e}"),
+            }
+        })?),
+    };
+
+    let existing = polling_tasks::Entity::find()
+        .filter(polling_tasks::Column::NodeId.eq(task.node_id.to_string()))
+        .one(&store.db)
+        .await
+        .map_err(|e| DataStoreError::InternalError {
+            message: format!(
+                "Failed to query existing polling task for {}: {e}",
+                task.node_id
+            ),
+        })?;
+
+    if existing.is_some() {
+        active_model
+            .update(&store.db)
+            .await
+            .map_err(|e| DataStoreError::InternalError {
+                message: format!("Failed to update polling task for {}: {e}", task.node_id),
+            })?;
+    } else {
+        active_model
+            .insert(&store.db)
+            .await
+            .map_err(|e| DataStoreError::InternalError {
+                message: format!("Failed to create polling task for {}: {e}", task.node_id),
+            })?;
+    }
+
+    get_node_polling_task(store, &task.node_id)
+        .await?
+        .ok_or_else(|| DataStoreError::NotFound {
+            entity_type: "PollingTask".to_string(),
+            id: task.node_id.to_string(),
+        })
+}
+
+fn entity_to_polling_task(entity: polling_tasks::Model) -> DataStoreResult<PollingTask> {
+    let id = entity
+        .id
+        .parse::<Uuid>()
+        .map_err(|e| DataStoreError::ValidationError {
+            message: format!("Invalid polling task UUID: {e}"),
+        })?;
+    let node_id = entity
+        .node_id
+        .parse::<Uuid>()
+        .map_err(|e| DataStoreError::ValidationError {
+            message: format!("Invalid polling task node UUID: {e}"),
+        })?;
+    let target = network::parse_socket_addr(&entity.target).map_err(|e| {
+        DataStoreError::ValidationError {
+            message: format!("Invalid polling task target '{}': {e}", entity.target),
+        }
+    })?;
+
+    Ok(PollingTask {
+        id,
+        target,
+        node_id,
+        oids: deserialize_json(&entity.oids, "polling_tasks.oids")?,
+        interval: Duration::from_secs(u64::try_from(entity.interval_seconds).map_err(|e| {
+            DataStoreError::ValidationError {
+                message: format!("Invalid polling interval: {e}"),
+            }
+        })?),
+        session_config: deserialize_json(&entity.session_config, "polling_tasks.session_config")?,
+        priority: u8::try_from(entity.priority).map_err(|e| DataStoreError::ValidationError {
+            message: format!("Invalid polling task priority: {e}"),
+        })?,
+        enabled: entity.enabled,
+        created_at: parse_timestamp(&entity.created_at, "polling_tasks.created_at")?,
+        last_success: entity
+            .last_success
+            .as_deref()
+            .map(|value| parse_timestamp(value, "polling_tasks.last_success"))
+            .transpose()?,
+        last_error: entity.last_error,
+        consecutive_failures: u32::try_from(entity.consecutive_failures).map_err(|e| {
+            DataStoreError::ValidationError {
+                message: format!("Invalid consecutive failure count: {e}"),
+            }
+        })?,
+    })
+}
+
+fn format_timestamp(value: SystemTime) -> String {
+    DateTime::<Utc>::from(value).to_rfc3339()
+}
+
+fn parse_timestamp(value: &str, field: &str) -> DataStoreResult<SystemTime> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&Utc).into())
+        .map_err(|e| DataStoreError::ValidationError {
+            message: format!("Invalid timestamp in {field}: {e}"),
+        })
+}
+
+fn serialize_json<T>(value: &T, field: &str) -> DataStoreResult<String>
+where
+    T: Serialize,
+{
+    serde_json::to_string(value).map_err(|e| DataStoreError::ValidationError {
+        message: format!("Invalid JSON in {field}: {e}"),
+    })
+}
+
+fn deserialize_json<T>(value: &str, field: &str) -> DataStoreResult<T>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_str(value).map_err(|e| DataStoreError::ValidationError {
+        message: format!("Invalid JSON in {field}: {e}"),
+    })
+}

--- a/crates/unet-core/src/datastore/sqlite/store.rs
+++ b/crates/unet-core/src/datastore/sqlite/store.rs
@@ -1,6 +1,6 @@
 //! Main `SQLite` store implementation
 
-use super::{derived_state, links, locations, metadata, nodes, vendors};
+use super::{derived_state, links, locations, metadata, nodes, polling_tasks, vendors};
 
 use super::super::DataStore;
 use super::super::types::{
@@ -232,6 +232,20 @@ impl DataStore for SqliteStore {
     ) -> DataStoreResult<Option<PerformanceMetrics>> {
         derived_state::get_node_metrics(self, node_id).await
     }
+
+    async fn get_node_polling_task(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Option<crate::snmp::PollingTask>> {
+        polling_tasks::get_node_polling_task(self, node_id).await
+    }
+
+    async fn upsert_polling_task(
+        &self,
+        task: &crate::snmp::PollingTask,
+    ) -> DataStoreResult<crate::snmp::PollingTask> {
+        polling_tasks::upsert_polling_task(self, task).await
+    }
 }
 
 #[cfg(test)]
@@ -245,3 +259,6 @@ mod derived_state_tests;
 
 #[cfg(test)]
 mod metadata_tests;
+
+#[cfg(test)]
+mod polling_tasks_tests;

--- a/crates/unet-core/src/datastore/sqlite/store/polling_tasks_tests.rs
+++ b/crates/unet-core/src/datastore/sqlite/store/polling_tasks_tests.rs
@@ -1,0 +1,129 @@
+use crate::config::defaults;
+use crate::datastore::DataStore;
+use crate::datastore::sqlite::SqliteStore;
+use crate::entities::{locations, nodes, polling_tasks, vendors};
+use crate::models::{DeviceRole, Lifecycle, NodeBuilder, Vendor};
+use crate::snmp::{PollingTask, SessionConfig};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, Database, DatabaseBackend, EntityTrait, QueryFilter, Schema,
+};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+use uuid::Uuid;
+
+async fn with_store<F, Fut>(f: F)
+where
+    F: FnOnce(SqliteStore) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let connection = Database::connect("sqlite::memory:")
+        .await
+        .expect("connect sqlite::memory:");
+    let schema = Schema::new(DatabaseBackend::Sqlite);
+
+    for stmt in [
+        schema.create_table_from_entity(vendors::Entity),
+        schema.create_table_from_entity(locations::Entity),
+        schema.create_table_from_entity(nodes::Entity),
+        schema.create_table_from_entity(polling_tasks::Entity),
+    ] {
+        connection
+            .execute(connection.get_database_backend().build(&stmt))
+            .await
+            .expect("apply schema");
+    }
+
+    f(SqliteStore::from_connection(connection)).await;
+}
+
+#[tokio::test]
+async fn test_get_node_polling_task_returns_persisted_task() {
+    with_store(|store| async move {
+        let node = NodeBuilder::new()
+            .id(Uuid::new_v4())
+            .name("edge-store-1")
+            .domain("example.com")
+            .vendor(Vendor::Cisco)
+            .model("ISR4321")
+            .role(DeviceRole::Router)
+            .lifecycle(Lifecycle::Live)
+            .management_ip(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)))
+            .build()
+            .unwrap();
+        store.create_node(&node).await.unwrap();
+
+        let task = PollingTask::new(
+            SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+                defaults::network::SNMP_DEFAULT_PORT,
+            ),
+            node.id,
+            vec!["1.3.6.1.2.1.1.1.0".to_string()],
+            Duration::from_secs(120),
+            SessionConfig::default(),
+        );
+
+        store.upsert_polling_task(&task).await.unwrap();
+
+        let saved = store
+            .get_node_polling_task(&node.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(saved.node_id, node.id);
+        assert_eq!(saved.target, task.target);
+        assert!(saved.enabled);
+        assert_eq!(saved.interval, Duration::from_secs(120));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_upsert_polling_task_updates_existing_row() {
+    with_store(|store| async move {
+        let node = NodeBuilder::new()
+            .id(Uuid::new_v4())
+            .name("edge-store-2")
+            .domain("example.com")
+            .vendor(Vendor::Cisco)
+            .model("ISR4321")
+            .role(DeviceRole::Router)
+            .lifecycle(Lifecycle::Live)
+            .management_ip(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 11)))
+            .build()
+            .unwrap();
+        store.create_node(&node).await.unwrap();
+
+        let mut task = PollingTask::new(
+            SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 11)),
+                defaults::network::SNMP_DEFAULT_PORT,
+            ),
+            node.id,
+            vec!["1.3.6.1.2.1.1.1.0".to_string()],
+            Duration::from_secs(300),
+            SessionConfig::default(),
+        );
+        store.upsert_polling_task(&task).await.unwrap();
+
+        task.enabled = false;
+        task.last_error = Some("disabled for maintenance".to_string());
+        task.consecutive_failures = 2;
+        store.upsert_polling_task(&task).await.unwrap();
+
+        let persisted = crate::entities::polling_tasks::Entity::find()
+            .filter(crate::entities::polling_tasks::Column::NodeId.eq(node.id.to_string()))
+            .one(store.connection())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(!persisted.enabled);
+        assert_eq!(
+            persisted.last_error.as_deref(),
+            Some("disabled for maintenance")
+        );
+        assert_eq!(persisted.consecutive_failures, 2);
+    })
+    .await;
+}

--- a/docs/src/cli_reference.md
+++ b/docs/src/cli_reference.md
@@ -595,7 +595,6 @@ unet import backup/
 ## Limitations (Current Version)
 
 - **Template engine**: Not yet implemented (planned for v0.2.0)
-- **SNMP polling controls**: Background polling runs automatically, but CLI controls are not implemented
 - **Node comparison and history**: Planned for future versions
 - **Table output formatting**: Currently defaults to JSON format
 - **Advanced filtering**: jq-style filters not yet implemented

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -22,11 +22,9 @@ This document outlines the planned features and release timeline for μNet.
 
 ### **Milestone 5: Advanced SNMP CLI**
 
-- **SNMP Polling Controls**: CLI commands to manage background polling
 - **Device Discovery**: Automatic capability detection
 - **Historical Metrics**: Time-series data storage and retrieval
 - **CLI Commands** (planned):
-  - `unet nodes polling start/stop/status`
   - `unet nodes history --metrics --since 1d`
   - `unet nodes compare <node1> <node2>`
 


### PR DESCRIPTION
## Summary
- add SQLite datastore support for reading and upserting persisted polling tasks
- replace local CLI polling placeholders with real `status`, `start`, `stop`, and `restart` behavior
- remove the unsupported `unet nodes polling history` action and reuse persisted polling state in `unet nodes status --status-type polling`
- update polling docs and test coverage for the new command behavior

## Testing
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' mise run test -- -p unet-core polling_tasks_tests`
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_DEV_DEBUG=0 RUSTFLAGS='-Cdebuginfo=0' mise run test -- -p unet-cli polling_exec_tests`
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_DEV_DEBUG=0 RUSTFLAGS='-Cdebuginfo=0' mise run test -- -p unet-cli monitoring_exec_tests`
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_DEV_DEBUG=0 RUSTFLAGS='-Cdebuginfo=0' mise run test -- -p unet-cli polling_tests`
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_DEV_DEBUG=0 RUSTFLAGS='-Cdebuginfo=0' mise run test -- -p unet-cli advanced_tests`
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo clippy -p unet-core`
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo clippy -p unet-cli`
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo clippy -p unet-server`
- `RUSTC_WRAPPER=/usr/bin/env CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 RUSTFLAGS='-Cdebuginfo=0' mise run lint`
- `mise run check-large-files`

## Notes
- The successful full-workspace lint run required explicit low-disk settings (`RUSTC_WRAPPER=/usr/bin/env`, `CARGO_BUILD_JOBS=1`, `CARGO_PROFILE_DEV_DEBUG=0`) because this checkout was repeatedly near the root volume limit.
- `cargo clippy --workspace --allow-dirty --fix` produced unrelated workspace rewrites during lint; those local-only rewrites were restored before continuing so the committed diff stays ticket-scoped.
