### PR TITLE
Back node history with stored derived-state snapshots

### DIFF
--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -5,6 +5,7 @@ mod m20241221_000002_create_nodes_table;
 mod m20241221_000003_create_links_table;
 mod m20241221_000004_create_derived_state_tables;
 mod m20241221_000005_create_vendor_table;
+mod m20260408_000006_relax_node_status_uniqueness;
 
 #[cfg(test)]
 mod schema_parity_tests;
@@ -20,6 +21,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20241221_000003_create_links_table::Migration),
             Box::new(m20241221_000004_create_derived_state_tables::Migration),
             Box::new(m20241221_000005_create_vendor_table::Migration),
+            Box::new(m20260408_000006_relax_node_status_uniqueness::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20260408_000006_relax_node_status_uniqueness.rs
+++ b/crates/migrations/src/m20260408_000006_relax_node_status_uniqueness.rs
@@ -1,0 +1,58 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_node_status_node_id")
+                    .table(NodeStatus::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_node_status_node_id_last_updated")
+                    .table(NodeStatus::Table)
+                    .col(NodeStatus::NodeId)
+                    .col(NodeStatus::LastUpdated)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_node_status_node_id_last_updated")
+                    .table(NodeStatus::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_node_status_node_id")
+                    .table(NodeStatus::Table)
+                    .col(NodeStatus::NodeId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum NodeStatus {
+    Table,
+    NodeId,
+    LastUpdated,
+}

--- a/crates/unet-cli/src/commands/nodes/dispatch_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/dispatch_tests.rs
@@ -53,6 +53,9 @@ mod tests {
             .expect_get_node_metrics()
             .returning(|_| ready_ok(None));
         store
+            .expect_get_node_status_history()
+            .returning(|_, _| ready_ok(Vec::new()));
+        store
     }
 
     #[tokio::test]

--- a/crates/unet-cli/src/commands/nodes/history.rs
+++ b/crates/unet-cli/src/commands/nodes/history.rs
@@ -1,6 +1,10 @@
-/// Node history operations
-use anyhow::Result;
-use unet_core::datastore::DataStore;
+/// Node history operations.
+use anyhow::{Result, anyhow};
+use chrono::{Duration, SecondsFormat, Utc};
+use serde_json::{Value, json};
+use std::time::SystemTime;
+use unet_core::datastore::{DataStore, HistoryQueryOptions};
+use unet_core::models::{Node, derived::NodeStatus};
 
 use super::types::{HistoryNodeArgs, HistoryType};
 
@@ -9,65 +13,183 @@ pub async fn history_node(
     datastore: &dyn DataStore,
     output_format: crate::OutputFormat,
 ) -> Result<()> {
-    // Verify node exists first
     let node = datastore.get_node_required(&args.id).await?;
+    let output = build_history_output(&node, args, datastore).await?;
+    crate::commands::print_output(&output, output_format)?;
+    Ok(())
+}
 
-    let mut output = serde_json::json!({
+pub(super) async fn build_history_output(
+    node: &Node,
+    args: HistoryNodeArgs,
+    datastore: &dyn DataStore,
+) -> Result<Value> {
+    let history = datastore
+        .get_node_status_history(
+            &args.id,
+            &HistoryQueryOptions {
+                limit: args.limit,
+                since: history_since(args.last_hours)?,
+            },
+        )
+        .await?;
+
+    let mut output = json!({
         "node_id": args.id,
-        "node_name": node.name,
+        "node_name": node.name.clone(),
         "history_type": format!("{:?}", args.history_type),
         "limit": args.limit,
         "last_hours": args.last_hours,
-        "detailed": args.detailed
+        "detailed": args.detailed,
     });
 
     match args.history_type {
         HistoryType::Status => {
-            output["status_history"] = serde_json::json!({
-                "message": "Status history display not yet implemented",
-                "note": "This would show historical node status changes",
-                "implementation_required": "Historical status tracking in database"
-            });
+            output["status_history"] = Value::Array(
+                history
+                    .iter()
+                    .map(|snapshot| status_entry(snapshot, args.detailed))
+                    .collect::<Vec<_>>(),
+            );
+            output["entry_count"] = json!(history.len());
         }
         HistoryType::Interfaces => {
-            output["interface_history"] = serde_json::json!({
-                "message": "Interface history display not yet implemented",
-                "note": "This would show interface status change history",
-                "implementation_required": "Interface status change tracking"
-            });
+            output["interface_history"] = Value::Array(
+                history
+                    .iter()
+                    .map(|snapshot| interface_entry(snapshot, args.detailed))
+                    .collect::<Vec<_>>(),
+            );
+            output["entry_count"] = json!(history.len());
         }
         HistoryType::Metrics => {
-            output["metrics_history"] = serde_json::json!({
-                "message": "Metrics history display not yet implemented",
-                "note": "This would show performance metrics over time",
-                "implementation_required": "Performance metrics time series storage"
-            });
+            let metrics_history = history.iter().filter_map(metrics_entry).collect::<Vec<_>>();
+            output["metrics_history"] = Value::Array(metrics_history.clone());
+            output["entry_count"] = json!(metrics_history.len());
         }
         HistoryType::System => {
-            output["system_history"] = serde_json::json!({
-                "message": "System information history not yet implemented",
-                "note": "This would show system information changes over time",
-                "implementation_required": "System information change tracking"
-            });
+            let system_history = history.iter().filter_map(system_entry).collect::<Vec<_>>();
+            output["system_history"] = Value::Array(system_history.clone());
+            output["entry_count"] = json!(system_history.len());
         }
         HistoryType::All => {
-            output["complete_history"] = serde_json::json!({
-                "message": "Complete history display not yet implemented",
-                "note": "This would show all types of historical data",
-                "implementation_required": "Comprehensive historical data aggregation"
-            });
+            output["complete_history"] = Value::Array(
+                history
+                    .iter()
+                    .map(|snapshot| complete_entry(snapshot, args.detailed))
+                    .collect::<Vec<_>>(),
+            );
+            output["entry_count"] = json!(history.len());
         }
     }
 
-    // Add implementation notes
-    output["implementation_notes"] = serde_json::json!({
-        "database_schema": "Historical data tables need to be designed and implemented",
-        "data_collection": "Background tasks for collecting and storing historical data",
-        "api_endpoints": "REST endpoints for querying historical data",
-        "cli_integration": "Command-line formatting for historical data display"
+    Ok(output)
+}
+
+fn history_since(last_hours: Option<u64>) -> Result<Option<SystemTime>> {
+    last_hours
+        .map(|hours| {
+            i64::try_from(hours)
+                .map_err(|_| anyhow!("--last-hours value is too large: {hours}"))
+                .map(|hours| (Utc::now() - Duration::hours(hours)).into())
+        })
+        .transpose()
+}
+
+fn status_entry(snapshot: &NodeStatus, detailed: bool) -> Value {
+    let mut entry = json!({
+        "last_updated": format_timestamp(snapshot.last_updated),
+        "reachable": snapshot.reachable,
+        "last_snmp_success": snapshot.last_snmp_success.map(format_timestamp),
+        "last_error": snapshot.last_error.clone(),
+        "consecutive_failures": snapshot.consecutive_failures,
     });
 
-    crate::commands::print_output(&output, output_format)?;
+    if detailed {
+        entry["system_info"] = json!(&snapshot.system_info);
+        entry["performance"] = json!(&snapshot.performance);
+        entry["interface_count"] = json!(snapshot.interfaces.len());
+    }
 
-    Ok(())
+    entry
+}
+
+fn interface_entry(snapshot: &NodeStatus, detailed: bool) -> Value {
+    let interfaces = if detailed {
+        json!(&snapshot.interfaces)
+    } else {
+        json!(
+            snapshot
+                .interfaces
+                .iter()
+                .map(|interface| {
+                    json!({
+                        "index": interface.index,
+                        "name": interface.name.clone(),
+                        "admin_status": interface.admin_status,
+                        "oper_status": interface.oper_status,
+                    })
+                })
+                .collect::<Vec<_>>()
+        )
+    };
+
+    json!({
+        "last_updated": format_timestamp(snapshot.last_updated),
+        "interfaces": interfaces,
+    })
+}
+
+fn metrics_entry(snapshot: &NodeStatus) -> Option<Value> {
+    snapshot.performance.as_ref().map(|performance| {
+        json!({
+            "last_updated": format_timestamp(snapshot.last_updated),
+            "metrics": performance,
+        })
+    })
+}
+
+fn system_entry(snapshot: &NodeStatus) -> Option<Value> {
+    snapshot.system_info.as_ref().map(|system_info| {
+        json!({
+            "last_updated": format_timestamp(snapshot.last_updated),
+            "system_info": system_info,
+        })
+    })
+}
+
+fn complete_entry(snapshot: &NodeStatus, detailed: bool) -> Value {
+    let mut entry = json!({
+        "last_updated": format_timestamp(snapshot.last_updated),
+        "reachable": snapshot.reachable,
+        "system_info": &snapshot.system_info,
+        "interfaces": if detailed {
+            json!(&snapshot.interfaces)
+        } else {
+            json!(snapshot.interfaces.iter().map(|interface| {
+                json!({
+                    "index": interface.index,
+                    "name": interface.name.clone(),
+                    "admin_status": interface.admin_status,
+                    "oper_status": interface.oper_status,
+                })
+            }).collect::<Vec<_>>())
+        },
+        "performance": &snapshot.performance,
+        "environmental": &snapshot.environmental,
+        "last_snmp_success": snapshot.last_snmp_success.map(format_timestamp),
+        "last_error": snapshot.last_error.clone(),
+        "consecutive_failures": snapshot.consecutive_failures,
+    });
+
+    if detailed {
+        entry["vendor_metrics"] = json!(&snapshot.vendor_metrics);
+        entry["raw_snmp_data"] = json!(&snapshot.raw_snmp_data);
+    }
+
+    entry
+}
+
+fn format_timestamp(value: SystemTime) -> String {
+    chrono::DateTime::<Utc>::from(value).to_rfc3339_opts(SecondsFormat::Secs, true)
 }

--- a/crates/unet-cli/src/commands/nodes/history_exec_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/history_exec_tests.rs
@@ -160,4 +160,62 @@ mod tests {
             assert!(!output.to_string().contains("implementation_required"));
         }
     }
+
+    #[tokio::test]
+    async fn test_build_history_output_simplifies_interfaces_when_not_detailed() {
+        let node = make_node();
+        let mut store = MockDataStore::new();
+        let history = vec![snapshot(node.id)];
+
+        store
+            .expect_get_node_status_history()
+            .times(2)
+            .returning(move |_, _| ready_ok(history.clone()));
+
+        let interface_output = build_history_output(
+            &node,
+            HistoryNodeArgs {
+                id: node.id,
+                history_type: HistoryType::Interfaces,
+                limit: 5,
+                last_hours: None,
+                detailed: false,
+            },
+            &store,
+        )
+        .await
+        .unwrap();
+
+        let interfaces = interface_output["interface_history"][0]["interfaces"]
+            .as_array()
+            .unwrap();
+        assert_eq!(
+            interfaces[0]["name"],
+            serde_json::json!("GigabitEthernet0/1")
+        );
+        assert!(interfaces[0]["speed"].is_null());
+
+        let complete_output = build_history_output(
+            &node,
+            HistoryNodeArgs {
+                id: node.id,
+                history_type: HistoryType::All,
+                limit: 5,
+                last_hours: None,
+                detailed: false,
+            },
+            &store,
+        )
+        .await
+        .unwrap();
+
+        let complete_interfaces = complete_output["complete_history"][0]["interfaces"]
+            .as_array()
+            .unwrap();
+        assert_eq!(
+            complete_interfaces[0]["oper_status"],
+            serde_json::json!(InterfaceOperStatus::Up)
+        );
+        assert!(complete_output["complete_history"][0]["vendor_metrics"].is_null());
+    }
 }

--- a/crates/unet-cli/src/commands/nodes/history_exec_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/history_exec_tests.rs
@@ -1,9 +1,13 @@
 /// Execution tests for node history command
 #[cfg(test)]
 mod tests {
-    use super::super::history::history_node;
+    use super::super::history::{build_history_output, history_node};
     use super::super::types::{HistoryNodeArgs, HistoryType};
     use unet_core::datastore::{MockDataStore, testing::ready_ok};
+    use unet_core::models::derived::{
+        InterfaceAdminStatus, InterfaceOperStatus, InterfaceStats, InterfaceStatus, NodeStatus,
+        PerformanceMetrics, SystemInfo,
+    };
     use uuid::Uuid;
 
     fn store_with_node(node: unet_core::models::Node) -> MockDataStore {
@@ -11,6 +15,9 @@ mod tests {
         store
             .expect_get_node_required()
             .returning(move |_| ready_ok(node.clone()));
+        store
+            .expect_get_node_status_history()
+            .returning(|_, _| ready_ok(Vec::new()));
         store
     }
 
@@ -27,6 +34,67 @@ mod tests {
             .lifecycle(Lifecycle::Live)
             .build()
             .unwrap()
+    }
+
+    fn snapshot(node_id: Uuid) -> NodeStatus {
+        NodeStatus {
+            node_id,
+            last_updated: chrono::DateTime::parse_from_rfc3339("2026-04-07T02:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)
+                .into(),
+            reachable: true,
+            system_info: Some(SystemInfo {
+                description: Some("edge-1 chassis".to_string()),
+                object_id: None,
+                uptime_ticks: Some(12_345),
+                contact: None,
+                name: Some("edge-1".to_string()),
+                location: Some("rack-22".to_string()),
+                services: Some(72),
+            }),
+            interfaces: vec![InterfaceStatus {
+                index: 1,
+                name: "GigabitEthernet0/1".to_string(),
+                interface_type: 6,
+                mtu: Some(1500),
+                speed: Some(1_000_000_000),
+                physical_address: Some("00:11:22:33:44:55".to_string()),
+                admin_status: InterfaceAdminStatus::Up,
+                oper_status: InterfaceOperStatus::Up,
+                last_change: Some(10),
+                input_stats: InterfaceStats {
+                    octets: 1000,
+                    packets: 10,
+                    errors: 0,
+                    discards: 0,
+                },
+                output_stats: InterfaceStats {
+                    octets: 2000,
+                    packets: 20,
+                    errors: 0,
+                    discards: 0,
+                },
+            }],
+            performance: Some(PerformanceMetrics {
+                cpu_utilization: Some(55),
+                memory_utilization: Some(70),
+                total_memory: Some(8192),
+                used_memory: Some(4096),
+                load_average: Some(0.5),
+            }),
+            environmental: None,
+            vendor_metrics: std::collections::HashMap::new(),
+            raw_snmp_data: std::collections::HashMap::new(),
+            last_snmp_success: Some(
+                chrono::DateTime::parse_from_rfc3339("2026-04-07T01:59:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc)
+                    .into(),
+            ),
+            last_error: None,
+            consecutive_failures: 0,
+        }
     }
 
     #[tokio::test]
@@ -50,6 +118,46 @@ mod tests {
             };
             let result = history_node(args, &store, crate::OutputFormat::Json).await;
             assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_history_output_uses_real_snapshots_for_all_supported_types() {
+        let node = make_node();
+        let mut store = MockDataStore::new();
+        let history = vec![snapshot(node.id)];
+
+        store
+            .expect_get_node_status_history()
+            .times(5)
+            .returning(move |_, _| ready_ok(history.clone()));
+
+        for (history_type, key) in [
+            (HistoryType::Status, "status_history"),
+            (HistoryType::Interfaces, "interface_history"),
+            (HistoryType::Metrics, "metrics_history"),
+            (HistoryType::System, "system_history"),
+            (HistoryType::All, "complete_history"),
+        ] {
+            let output = build_history_output(
+                &node,
+                HistoryNodeArgs {
+                    id: node.id,
+                    history_type: history_type.clone(),
+                    limit: 5,
+                    last_hours: Some(24),
+                    detailed: true,
+                },
+                &store,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(output["node_id"], serde_json::json!(node.id));
+            assert!(output[key].is_array(), "missing array payload for {key}");
+            assert_eq!(output[key].as_array().unwrap().len(), 1);
+            assert!(output.to_string().contains("edge-1"));
+            assert!(!output.to_string().contains("implementation_required"));
         }
     }
 }

--- a/crates/unet-cli/src/commands/nodes/history_tests.rs
+++ b/crates/unet-cli/src/commands/nodes/history_tests.rs
@@ -100,7 +100,7 @@ mod exec_tests {
     use crate::commands::nodes::history::history_node;
     use crate::commands::nodes::types::{HistoryNodeArgs, HistoryType};
     use mockall::predicate::eq;
-    use unet_core::datastore::MockDataStore;
+    use unet_core::datastore::{MockDataStore, testing::ready_ok};
     use unet_core::models::{DeviceRole, NodeBuilder, Vendor};
     use uuid::Uuid;
 
@@ -125,6 +125,8 @@ mod exec_tests {
                 let node = node.clone();
                 Box::pin(async move { Ok(node) })
             });
+        mock.expect_get_node_status_history()
+            .returning(|_, _| ready_ok(Vec::new()));
 
         // Exercise each HistoryType arm
         for history_type in [

--- a/crates/unet-cli/src/commands/nodes/mod.rs
+++ b/crates/unet-cli/src/commands/nodes/mod.rs
@@ -31,6 +31,8 @@ mod delete_exec_tests;
 #[cfg(test)]
 mod dispatch_tests;
 #[cfg(test)]
+mod history_exec_tests;
+#[cfg(test)]
 mod history_tests;
 #[cfg(test)]
 mod list_tests;

--- a/crates/unet-cli/src/dry_run.rs
+++ b/crates/unet-cli/src/dry_run.rs
@@ -257,7 +257,7 @@ impl DataStore for DryRunStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use unet_core::datastore::MockDataStore;
+    use unet_core::datastore::{MockDataStore, testing::ready_ok};
     use unet_core::models::{DeviceRole, NodeBuilder, Vendor};
 
     #[tokio::test]
@@ -277,5 +277,23 @@ mod tests {
         let updated = store.update_node(&node).await.unwrap();
         assert_eq!(updated.name, node.name);
         assert!(store.delete_node(&node.id).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_update_node_custom_data_returns_not_found_for_missing_node() {
+        let node_id = Uuid::new_v4();
+        let mut mock = MockDataStore::new();
+        mock.expect_get_node().returning(|_| ready_ok(None));
+        let store = DryRunStore::new(Arc::new(mock));
+
+        let error = store
+            .update_node_custom_data(&node_id, &serde_json::json!({"role": "missing"}))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            unet_core::datastore::types::DataStoreError::NotFound { .. }
+        ));
     }
 }

--- a/crates/unet-cli/src/dry_run.rs
+++ b/crates/unet-cli/src/dry_run.rs
@@ -1,7 +1,9 @@
-use std::sync::Arc;
 use async_trait::async_trait;
+use std::sync::Arc;
 use tracing::info;
-use unet_core::datastore::types::{BatchResult, DataStoreError, DataStoreResult, PagedResult, QueryOptions};
+use unet_core::datastore::types::{
+    BatchResult, DataStoreError, DataStoreResult, HistoryQueryOptions, PagedResult, QueryOptions,
+};
 use unet_core::datastore::{BatchOperation, DataStore, Transaction};
 use unet_core::models::{Link, Location, Node};
 use unet_core::policy::PolicyExecutionResult;
@@ -12,23 +14,35 @@ pub struct DryRunStore {
 }
 
 impl DryRunStore {
-    pub fn new(inner: Arc<dyn DataStore>) -> Self { Self { inner } }
+    pub fn new(inner: Arc<dyn DataStore>) -> Self {
+        Self { inner }
+    }
 }
 
 #[async_trait]
 impl DataStore for DryRunStore {
-    fn name(&self) -> &'static str { "dry-run" }
+    fn name(&self) -> &'static str {
+        "dry-run"
+    }
 
-    async fn health_check(&self) -> DataStoreResult<()> { self.inner.health_check().await }
-    async fn begin_transaction(&self) -> DataStoreResult<Box<dyn Transaction>> { self.inner.begin_transaction().await }
+    async fn health_check(&self) -> DataStoreResult<()> {
+        self.inner.health_check().await
+    }
+    async fn begin_transaction(&self) -> DataStoreResult<Box<dyn Transaction>> {
+        self.inner.begin_transaction().await
+    }
 
     // Node ops
     async fn create_node(&self, node: &Node) -> DataStoreResult<Node> {
         info!("[dry-run] create_node: {}", node.name);
         Ok(node.clone())
     }
-    async fn get_node(&self, id: &Uuid) -> DataStoreResult<Option<Node>> { self.inner.get_node(id).await }
-    async fn list_nodes(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Node>> { self.inner.list_nodes(options).await }
+    async fn get_node(&self, id: &Uuid) -> DataStoreResult<Option<Node>> {
+        self.inner.get_node(id).await
+    }
+    async fn list_nodes(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Node>> {
+        self.inner.list_nodes(options).await
+    }
     async fn update_node(&self, node: &Node) -> DataStoreResult<Node> {
         info!("[dry-run] update_node: {}", node.name);
         Ok(node.clone())
@@ -37,16 +51,24 @@ impl DataStore for DryRunStore {
         info!("[dry-run] delete_node: {}", id);
         Ok(())
     }
-    async fn get_nodes_by_location(&self, location_id: &Uuid) -> DataStoreResult<Vec<Node>> { self.inner.get_nodes_by_location(location_id).await }
-    async fn search_nodes_by_name(&self, name: &str) -> DataStoreResult<Vec<Node>> { self.inner.search_nodes_by_name(name).await }
+    async fn get_nodes_by_location(&self, location_id: &Uuid) -> DataStoreResult<Vec<Node>> {
+        self.inner.get_nodes_by_location(location_id).await
+    }
+    async fn search_nodes_by_name(&self, name: &str) -> DataStoreResult<Vec<Node>> {
+        self.inner.search_nodes_by_name(name).await
+    }
 
     // Link ops
     async fn create_link(&self, link: &Link) -> DataStoreResult<Link> {
         info!("[dry-run] create_link: {}", link.name);
         Ok(link.clone())
     }
-    async fn get_link(&self, id: &Uuid) -> DataStoreResult<Option<Link>> { self.inner.get_link(id).await }
-    async fn list_links(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Link>> { self.inner.list_links(options).await }
+    async fn get_link(&self, id: &Uuid) -> DataStoreResult<Option<Link>> {
+        self.inner.get_link(id).await
+    }
+    async fn list_links(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Link>> {
+        self.inner.list_links(options).await
+    }
     async fn update_link(&self, link: &Link) -> DataStoreResult<Link> {
         info!("[dry-run] update_link: {}", link.name);
         Ok(link.clone())
@@ -55,16 +77,27 @@ impl DataStore for DryRunStore {
         info!("[dry-run] delete_link: {}", id);
         Ok(())
     }
-    async fn get_links_for_node(&self, node_id: &Uuid) -> DataStoreResult<Vec<Link>> { self.inner.get_links_for_node(node_id).await }
-    async fn get_links_between_nodes(&self, a: &Uuid, b: &Uuid) -> DataStoreResult<Vec<Link>> { self.inner.get_links_between_nodes(a, b).await }
+    async fn get_links_for_node(&self, node_id: &Uuid) -> DataStoreResult<Vec<Link>> {
+        self.inner.get_links_for_node(node_id).await
+    }
+    async fn get_links_between_nodes(&self, a: &Uuid, b: &Uuid) -> DataStoreResult<Vec<Link>> {
+        self.inner.get_links_between_nodes(a, b).await
+    }
 
     // Location ops
     async fn create_location(&self, location: &Location) -> DataStoreResult<Location> {
         info!("[dry-run] create_location: {}", location.name);
         Ok(location.clone())
     }
-    async fn get_location(&self, id: &Uuid) -> DataStoreResult<Option<Location>> { self.inner.get_location(id).await }
-    async fn list_locations(&self, options: &QueryOptions) -> DataStoreResult<PagedResult<Location>> { self.inner.list_locations(options).await }
+    async fn get_location(&self, id: &Uuid) -> DataStoreResult<Option<Location>> {
+        self.inner.get_location(id).await
+    }
+    async fn list_locations(
+        &self,
+        options: &QueryOptions,
+    ) -> DataStoreResult<PagedResult<Location>> {
+        self.inner.list_locations(options).await
+    }
     async fn update_location(&self, location: &Location) -> DataStoreResult<Location> {
         info!("[dry-run] update_location: {}", location.name);
         Ok(location.clone())
@@ -79,54 +112,146 @@ impl DataStore for DryRunStore {
         info!("[dry-run] create_vendor: {}", name);
         Ok(())
     }
-    async fn list_vendors(&self) -> DataStoreResult<Vec<String>> { self.inner.list_vendors().await }
+    async fn list_vendors(&self) -> DataStoreResult<Vec<String>> {
+        self.inner.list_vendors().await
+    }
     async fn delete_vendor(&self, name: &str) -> DataStoreResult<()> {
         info!("[dry-run] delete_vendor: {}", name);
         Ok(())
     }
 
     // Batch
-    async fn batch_nodes(&self, operations: &[BatchOperation<Node>]) -> DataStoreResult<BatchResult> {
+    async fn batch_nodes(
+        &self,
+        operations: &[BatchOperation<Node>],
+    ) -> DataStoreResult<BatchResult> {
         info!("[dry-run] batch_nodes: {} ops", operations.len());
-        Ok(BatchResult { success_count: operations.len(), error_count: 0, errors: vec![] })
+        Ok(BatchResult {
+            success_count: operations.len(),
+            error_count: 0,
+            errors: vec![],
+        })
     }
-    async fn batch_links(&self, operations: &[BatchOperation<Link>]) -> DataStoreResult<BatchResult> {
+    async fn batch_links(
+        &self,
+        operations: &[BatchOperation<Link>],
+    ) -> DataStoreResult<BatchResult> {
         info!("[dry-run] batch_links: {} ops", operations.len());
-        Ok(BatchResult { success_count: operations.len(), error_count: 0, errors: vec![] })
+        Ok(BatchResult {
+            success_count: operations.len(),
+            error_count: 0,
+            errors: vec![],
+        })
     }
-    async fn batch_locations(&self, operations: &[BatchOperation<Location>]) -> DataStoreResult<BatchResult> {
+    async fn batch_locations(
+        &self,
+        operations: &[BatchOperation<Location>],
+    ) -> DataStoreResult<BatchResult> {
         info!("[dry-run] batch_locations: {} ops", operations.len());
-        Ok(BatchResult { success_count: operations.len(), error_count: 0, errors: vec![] })
+        Ok(BatchResult {
+            success_count: operations.len(),
+            error_count: 0,
+            errors: vec![],
+        })
     }
 
     // Stats
-    async fn get_entity_counts(&self) -> DataStoreResult<std::collections::HashMap<String, usize>> { self.inner.get_entity_counts().await }
-    async fn get_statistics(&self) -> DataStoreResult<std::collections::HashMap<String, serde_json::Value>> { self.inner.get_statistics().await }
+    async fn get_entity_counts(&self) -> DataStoreResult<std::collections::HashMap<String, usize>> {
+        self.inner.get_entity_counts().await
+    }
+    async fn get_statistics(
+        &self,
+    ) -> DataStoreResult<std::collections::HashMap<String, serde_json::Value>> {
+        self.inner.get_statistics().await
+    }
 
     // Derived state
-    async fn get_node_status(&self, node_id: &Uuid) -> DataStoreResult<Option<unet_core::models::derived::NodeStatus>> { self.inner.get_node_status(node_id).await }
-    async fn get_node_interfaces(&self, node_id: &Uuid) -> DataStoreResult<Vec<unet_core::models::derived::InterfaceStatus>> { self.inner.get_node_interfaces(node_id).await }
-    async fn get_node_metrics(&self, node_id: &Uuid) -> DataStoreResult<Option<unet_core::models::derived::PerformanceMetrics>> { self.inner.get_node_metrics(node_id).await }
+    async fn get_node_status(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Option<unet_core::models::derived::NodeStatus>> {
+        self.inner.get_node_status(node_id).await
+    }
+    async fn get_node_interfaces(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Vec<unet_core::models::derived::InterfaceStatus>> {
+        self.inner.get_node_interfaces(node_id).await
+    }
+    async fn get_node_metrics(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Option<unet_core::models::derived::PerformanceMetrics>> {
+        self.inner.get_node_metrics(node_id).await
+    }
+    async fn store_node_status_snapshot(
+        &self,
+        snapshot: &unet_core::models::derived::NodeStatus,
+    ) -> DataStoreResult<()> {
+        self.inner.store_node_status_snapshot(snapshot).await
+    }
+    async fn get_node_status_history(
+        &self,
+        node_id: &Uuid,
+        options: &HistoryQueryOptions,
+    ) -> DataStoreResult<Vec<unet_core::models::derived::NodeStatus>> {
+        self.inner.get_node_status_history(node_id, options).await
+    }
 
     // Policy
-    async fn store_policy_result(&self, node_id: &Uuid, rule_id: &str, result: &PolicyExecutionResult) -> DataStoreResult<()> {
-        info!("[dry-run] store_policy_result: node={} rule={} result={:?}", node_id, rule_id, result);
+    async fn store_policy_result(
+        &self,
+        node_id: &Uuid,
+        rule_id: &str,
+        result: &PolicyExecutionResult,
+    ) -> DataStoreResult<()> {
+        info!(
+            "[dry-run] store_policy_result: node={} rule={} result={:?}",
+            node_id, rule_id, result
+        );
         Ok(())
     }
-    async fn get_policy_results(&self, node_id: &Uuid) -> DataStoreResult<Vec<PolicyExecutionResult>> { self.inner.get_policy_results(node_id).await }
-    async fn get_latest_policy_results(&self, node_id: &Uuid) -> DataStoreResult<Vec<PolicyExecutionResult>> { self.inner.get_latest_policy_results(node_id).await }
-    async fn get_rule_results(&self, rule_id: &str) -> DataStoreResult<Vec<(Uuid, PolicyExecutionResult)>> { self.inner.get_rule_results(rule_id).await }
+    async fn get_policy_results(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Vec<PolicyExecutionResult>> {
+        self.inner.get_policy_results(node_id).await
+    }
+    async fn get_latest_policy_results(
+        &self,
+        node_id: &Uuid,
+    ) -> DataStoreResult<Vec<PolicyExecutionResult>> {
+        self.inner.get_latest_policy_results(node_id).await
+    }
+    async fn get_rule_results(
+        &self,
+        rule_id: &str,
+    ) -> DataStoreResult<Vec<(Uuid, PolicyExecutionResult)>> {
+        self.inner.get_rule_results(rule_id).await
+    }
 
-    async fn update_node_custom_data(&self, node_id: &Uuid, custom_data: &serde_json::Value) -> DataStoreResult<()> {
-        info!("[dry-run] update_node_custom_data: {} -> {}", node_id, custom_data);
+    async fn update_node_custom_data(
+        &self,
+        node_id: &Uuid,
+        custom_data: &serde_json::Value,
+    ) -> DataStoreResult<()> {
+        info!(
+            "[dry-run] update_node_custom_data: {} -> {}",
+            node_id, custom_data
+        );
         // Optionally verify node exists
         if self.inner.get_node(node_id).await?.is_none() {
-            return Err(DataStoreError::NotFound { entity_type: "Node".into(), id: node_id.to_string() });
+            return Err(DataStoreError::NotFound {
+                entity_type: "Node".into(),
+                id: node_id.to_string(),
+            });
         }
         Ok(())
     }
 
-    async fn get_nodes_for_policy_evaluation(&self) -> DataStoreResult<Vec<Node>> { self.inner.get_nodes_for_policy_evaluation().await }
+    async fn get_nodes_for_policy_evaluation(&self) -> DataStoreResult<Vec<Node>> {
+        self.inner.get_nodes_for_policy_evaluation().await
+    }
 }
 
 #[cfg(test)]
@@ -138,8 +263,13 @@ mod tests {
     #[tokio::test]
     async fn test_dry_run_create_update_delete_node_ok() {
         let node = NodeBuilder::new()
-            .name("n1").domain("example.com").vendor(Vendor::Cisco).model("ISR").role(DeviceRole::Router)
-            .build().unwrap();
+            .name("n1")
+            .domain("example.com")
+            .vendor(Vendor::Cisco)
+            .model("ISR")
+            .role(DeviceRole::Router)
+            .build()
+            .unwrap();
         let mock = MockDataStore::new();
         let store = DryRunStore::new(Arc::new(mock));
         let created = store.create_node(&node).await.unwrap();

--- a/crates/unet-cli/src/dry_run_tests.rs
+++ b/crates/unet-cli/src/dry_run_tests.rs
@@ -1,0 +1,295 @@
+use crate::dry_run::DryRunStore;
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use unet_core::datastore::types::{HistoryQueryOptions, PagedResult, QueryOptions};
+use unet_core::datastore::{BatchOperation, DataStore, MockDataStore, testing::ready_ok};
+use unet_core::models::derived::{NodeStatus, PerformanceMetrics};
+use unet_core::models::{DeviceRole, Link, Location, Node, NodeBuilder, Vendor};
+use unet_core::policy::{Action, Condition, FieldRef, PolicyExecutionResult};
+use unet_core::policy::{PolicyRule, Value as PolicyValue};
+use uuid::Uuid;
+
+fn make_node() -> Node {
+    NodeBuilder::new()
+        .id(Uuid::new_v4())
+        .name("edge-1")
+        .domain("example.com")
+        .vendor(Vendor::Cisco)
+        .model("ISR4321")
+        .role(DeviceRole::Router)
+        .build()
+        .unwrap()
+}
+
+fn make_policy_result() -> PolicyExecutionResult {
+    PolicyExecutionResult::new_error(
+        PolicyRule {
+            id: Some("rule-1".to_string()),
+            condition: Condition::True,
+            action: Action::Assert {
+                field: FieldRef {
+                    path: vec!["node".to_string(), "name".to_string()],
+                },
+                expected: PolicyValue::String("edge-1".to_string()),
+            },
+        },
+        "boom".to_string(),
+    )
+}
+
+#[tokio::test]
+async fn test_dry_run_store_covers_forwarded_read_and_history_paths() {
+    let node = make_node();
+    let other_node = make_node();
+    let link = Link::new(
+        "wan-link".to_string(),
+        node.id,
+        "Gi0/0".to_string(),
+        other_node.id,
+        "Gi0/1".to_string(),
+    );
+    let location = Location::new_root("HQ".to_string(), "building".to_string());
+    let options = QueryOptions {
+        filters: Vec::new(),
+        sort: Vec::new(),
+        pagination: None,
+    };
+    let history_options = HistoryQueryOptions {
+        limit: 5,
+        since: None,
+    };
+    let status = NodeStatus::new(node.id);
+    let interfaces = status.interfaces.clone();
+    let metrics = Some(PerformanceMetrics {
+        cpu_utilization: Some(55),
+        memory_utilization: Some(70),
+        total_memory: Some(8192),
+        used_memory: Some(4096),
+        load_average: Some(0.5),
+    });
+    let history = vec![status.clone()];
+    let policy_result = make_policy_result();
+    let entity_counts = HashMap::from([("nodes".to_string(), 1usize)]);
+    let statistics = HashMap::from([("nodes_total".to_string(), json!(1))]);
+    let rule_results = vec![(node.id, policy_result.clone())];
+
+    let mut mock = MockDataStore::new();
+    mock.expect_health_check().returning(|| ready_ok(()));
+    mock.expect_get_node().times(2).returning({
+        let node = node.clone();
+        move |_| ready_ok(Some(node.clone()))
+    });
+    mock.expect_list_nodes().returning({
+        let node = node.clone();
+        move |_| ready_ok(PagedResult::new(vec![node.clone()], 1, None))
+    });
+    mock.expect_get_nodes_by_location().returning({
+        let node = node.clone();
+        move |_| ready_ok(vec![node.clone()])
+    });
+    mock.expect_search_nodes_by_name().returning({
+        let node = node.clone();
+        move |_| ready_ok(vec![node.clone()])
+    });
+    mock.expect_get_link().returning({
+        let link = link.clone();
+        move |_| ready_ok(Some(link.clone()))
+    });
+    mock.expect_list_links().returning({
+        let link = link.clone();
+        move |_| ready_ok(PagedResult::new(vec![link.clone()], 1, None))
+    });
+    mock.expect_get_links_for_node().returning({
+        let link = link.clone();
+        move |_| ready_ok(vec![link.clone()])
+    });
+    mock.expect_get_links_between_nodes().returning({
+        let link = link.clone();
+        move |_, _| ready_ok(vec![link.clone()])
+    });
+    mock.expect_get_location().returning({
+        let location = location.clone();
+        move |_| ready_ok(Some(location.clone()))
+    });
+    mock.expect_list_locations().returning({
+        let location = location.clone();
+        move |_| ready_ok(PagedResult::new(vec![location.clone()], 1, None))
+    });
+    mock.expect_list_vendors()
+        .returning(|| ready_ok(vec!["Cisco".to_string()]));
+    mock.expect_get_entity_counts().returning({
+        let entity_counts = entity_counts.clone();
+        move || ready_ok(entity_counts.clone())
+    });
+    mock.expect_get_statistics().returning({
+        let statistics = statistics.clone();
+        move || ready_ok(statistics.clone())
+    });
+    mock.expect_get_node_status().returning({
+        let status = status.clone();
+        move |_| ready_ok(Some(status.clone()))
+    });
+    mock.expect_get_node_interfaces().returning({
+        let interfaces = interfaces.clone();
+        move |_| ready_ok(interfaces.clone())
+    });
+    mock.expect_get_node_metrics().returning({
+        let metrics = metrics.clone();
+        move |_| ready_ok(metrics.clone())
+    });
+    mock.expect_store_node_status_snapshot()
+        .returning(|_| ready_ok(()));
+    mock.expect_get_node_status_history().returning({
+        let history = history.clone();
+        move |_, options| {
+            assert_eq!(options.limit, 5);
+            ready_ok(history.clone())
+        }
+    });
+    mock.expect_get_policy_results().returning({
+        let policy_result = policy_result.clone();
+        move |_| ready_ok(vec![policy_result.clone()])
+    });
+    mock.expect_get_latest_policy_results().returning({
+        let policy_result = policy_result.clone();
+        move |_| ready_ok(vec![policy_result.clone()])
+    });
+    mock.expect_get_rule_results().returning({
+        let rule_results = rule_results.clone();
+        move |_| ready_ok(rule_results.clone())
+    });
+    mock.expect_get_nodes_for_policy_evaluation().returning({
+        let node = node.clone();
+        move || ready_ok(vec![node.clone()])
+    });
+
+    let store = DryRunStore::new(Arc::new(mock));
+
+    assert_eq!(store.name(), "dry-run");
+    store.health_check().await.unwrap();
+    assert_eq!(store.get_node(&node.id).await.unwrap(), Some(node.clone()));
+    assert_eq!(
+        store.list_nodes(&options).await.unwrap().items,
+        vec![node.clone()]
+    );
+    assert_eq!(
+        store.get_nodes_by_location(&location.id).await.unwrap(),
+        vec![node.clone()]
+    );
+    assert_eq!(
+        store.search_nodes_by_name("edge").await.unwrap(),
+        vec![node.clone()]
+    );
+    assert_eq!(store.create_link(&link).await.unwrap(), link.clone());
+    assert_eq!(store.get_link(&link.id).await.unwrap(), Some(link.clone()));
+    assert_eq!(
+        store.list_links(&options).await.unwrap().items,
+        vec![link.clone()]
+    );
+    assert_eq!(store.update_link(&link).await.unwrap(), link.clone());
+    assert!(store.delete_link(&link.id).await.is_ok());
+    assert_eq!(
+        store.get_links_for_node(&node.id).await.unwrap(),
+        vec![link.clone()]
+    );
+    assert_eq!(
+        store
+            .get_links_between_nodes(&node.id, &other_node.id)
+            .await
+            .unwrap(),
+        vec![link.clone()]
+    );
+    assert_eq!(
+        store.create_location(&location).await.unwrap(),
+        location.clone()
+    );
+    assert_eq!(
+        store.get_location(&location.id).await.unwrap(),
+        Some(location.clone())
+    );
+    assert_eq!(
+        store.list_locations(&options).await.unwrap().items,
+        vec![location.clone()]
+    );
+    assert_eq!(
+        store.update_location(&location).await.unwrap(),
+        location.clone()
+    );
+    assert!(store.delete_location(&location.id).await.is_ok());
+    assert!(store.create_vendor("Cisco").await.is_ok());
+    assert_eq!(
+        store.list_vendors().await.unwrap(),
+        vec!["Cisco".to_string()]
+    );
+    assert!(store.delete_vendor("Cisco").await.is_ok());
+    assert_eq!(
+        store
+            .batch_nodes(&[BatchOperation::Insert(node.clone())])
+            .await
+            .unwrap()
+            .success_count,
+        1
+    );
+    assert_eq!(
+        store
+            .batch_links(&[BatchOperation::Insert(link.clone())])
+            .await
+            .unwrap()
+            .success_count,
+        1
+    );
+    assert_eq!(
+        store
+            .batch_locations(&[BatchOperation::Insert(location.clone())])
+            .await
+            .unwrap()
+            .success_count,
+        1
+    );
+    assert_eq!(store.get_entity_counts().await.unwrap(), entity_counts);
+    assert_eq!(store.get_statistics().await.unwrap(), statistics);
+    assert_eq!(
+        store.get_node_status(&node.id).await.unwrap(),
+        Some(status.clone())
+    );
+    assert_eq!(
+        store.get_node_interfaces(&node.id).await.unwrap(),
+        interfaces
+    );
+    assert_eq!(store.get_node_metrics(&node.id).await.unwrap(), metrics);
+    assert!(store.store_node_status_snapshot(&status).await.is_ok());
+    assert_eq!(
+        store
+            .get_node_status_history(&node.id, &history_options)
+            .await
+            .unwrap(),
+        history
+    );
+    assert!(
+        store
+            .store_policy_result(&node.id, "rule-1", &policy_result)
+            .await
+            .is_ok()
+    );
+    let policy_results = store.get_policy_results(&node.id).await.unwrap();
+    assert_eq!(policy_results.len(), 1);
+    assert_eq!(policy_results[0].rule.id.as_deref(), Some("rule-1"));
+    let latest_policy_results = store.get_latest_policy_results(&node.id).await.unwrap();
+    assert_eq!(latest_policy_results.len(), 1);
+    assert_eq!(latest_policy_results[0].rule.id.as_deref(), Some("rule-1"));
+    let fetched_rule_results = store.get_rule_results("rule-1").await.unwrap();
+    assert_eq!(fetched_rule_results.len(), 1);
+    assert_eq!(fetched_rule_results[0].0, node.id);
+    assert_eq!(fetched_rule_results[0].1.rule.id.as_deref(), Some("rule-1"));
+    assert!(
+        store
+            .update_node_custom_data(&node.id, &json!({"role": "edge"}))
+            .await
+            .is_ok()
+    );
+    assert_eq!(
+        store.get_nodes_for_policy_evaluation().await.unwrap(),
+        vec![node]
+    );
+}

--- a/crates/unet-cli/src/lib.rs
+++ b/crates/unet-cli/src/lib.rs
@@ -9,6 +9,8 @@ use unet_core::prelude::*;
 
 pub mod commands;
 pub mod dry_run;
+#[cfg(test)]
+mod dry_run_tests;
 mod remote;
 pub mod runtime;
 

--- a/crates/unet-core/src/datastore/mod.rs
+++ b/crates/unet-core/src/datastore/mod.rs
@@ -22,7 +22,8 @@ pub mod types;
 // Re-export main types for backward compatibility
 pub use types::{
     BatchOperation, BatchResult, DataStoreError, DataStoreResult, Filter, FilterOperation,
-    FilterValue, PagedResult, Pagination, QueryOptions, Sort, SortDirection, Transaction,
+    FilterValue, HistoryQueryOptions, PagedResult, Pagination, QueryOptions, Sort, SortDirection,
+    Transaction,
 };
 
 pub use helpers::{filter_contains, filter_equals_string, filter_equals_uuid, sort_asc, sort_desc};
@@ -292,6 +293,27 @@ pub trait DataStore: Send + Sync {
     ) -> DataStoreResult<Option<crate::models::derived::PerformanceMetrics>> {
         Err(DataStoreError::UnsupportedOperation {
             operation: "get_node_metrics".to_string(),
+        })
+    }
+
+    /// Stores a derived-state snapshot for historical queries.
+    async fn store_node_status_snapshot(
+        &self,
+        _snapshot: &crate::models::derived::NodeStatus,
+    ) -> DataStoreResult<()> {
+        Err(DataStoreError::UnsupportedOperation {
+            operation: "store_node_status_snapshot".to_string(),
+        })
+    }
+
+    /// Gets historical derived-state snapshots for a specific node.
+    async fn get_node_status_history(
+        &self,
+        _node_id: &Uuid,
+        _options: &HistoryQueryOptions,
+    ) -> DataStoreResult<Vec<crate::models::derived::NodeStatus>> {
+        Err(DataStoreError::UnsupportedOperation {
+            operation: "get_node_status_history".to_string(),
         })
     }
 

--- a/crates/unet-core/src/datastore/sqlite/derived_state.rs
+++ b/crates/unet-core/src/datastore/sqlite/derived_state.rs
@@ -1,73 +1,41 @@
-//! Derived-state queries for the `SQLite` datastore
+//! Latest derived-state lookups for the `SQLite` datastore.
 
-use super::SqliteStore;
-use super::conversions::{entity_to_interface_status, entity_to_node_status, parse_optional_json};
-use crate::datastore::types::{DataStoreError, DataStoreResult};
-use crate::entities::{interface_status, node_status};
+use super::{SqliteStore, derived_state_history};
+use crate::datastore::{DataStoreResult, HistoryQueryOptions};
 use crate::models::derived::{InterfaceStatus, NodeStatus, PerformanceMetrics};
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 use uuid::Uuid;
 
 pub async fn get_node_status(
     store: &SqliteStore,
     node_id: &Uuid,
 ) -> DataStoreResult<Option<NodeStatus>> {
-    let Some(status_entity) = get_node_status_entity(store, node_id).await? else {
-        return Ok(None);
-    };
-    let interfaces = interface_status::Entity::find()
-        .filter(interface_status::Column::NodeStatusId.eq(status_entity.id.clone()))
-        .order_by_asc(interface_status::Column::Index)
-        .all(&store.db)
-        .await
-        .map_err(|e| DataStoreError::InternalError {
-            message: format!("Failed to query interface status for node {node_id}: {e}"),
-        })?;
-
-    entity_to_node_status(status_entity, interfaces).map(Some)
+    Ok(derived_state_history::get_node_status_history(
+        store,
+        node_id,
+        &HistoryQueryOptions {
+            limit: 1,
+            since: None,
+        },
+    )
+    .await?
+    .into_iter()
+    .next())
 }
 
 pub async fn get_node_interfaces(
     store: &SqliteStore,
     node_id: &Uuid,
 ) -> DataStoreResult<Vec<InterfaceStatus>> {
-    let Some(status_entity) = get_node_status_entity(store, node_id).await? else {
-        return Ok(Vec::new());
-    };
-
-    interface_status::Entity::find()
-        .filter(interface_status::Column::NodeStatusId.eq(status_entity.id))
-        .order_by_asc(interface_status::Column::Index)
-        .all(&store.db)
-        .await
-        .map_err(|e| DataStoreError::InternalError {
-            message: format!("Failed to query interface status for node {node_id}: {e}"),
-        })?
-        .into_iter()
-        .map(entity_to_interface_status)
-        .collect()
+    Ok(get_node_status(store, node_id)
+        .await?
+        .map_or_else(Vec::new, |status| status.interfaces))
 }
 
 pub async fn get_node_metrics(
     store: &SqliteStore,
     node_id: &Uuid,
 ) -> DataStoreResult<Option<PerformanceMetrics>> {
-    let Some(status_entity) = get_node_status_entity(store, node_id).await? else {
-        return Ok(None);
-    };
-
-    parse_optional_json(status_entity.performance, "node_status.performance")
-}
-
-async fn get_node_status_entity(
-    store: &SqliteStore,
-    node_id: &Uuid,
-) -> DataStoreResult<Option<node_status::Model>> {
-    node_status::Entity::find()
-        .filter(node_status::Column::NodeId.eq(node_id.to_string()))
-        .one(&store.db)
-        .await
-        .map_err(|e| DataStoreError::InternalError {
-            message: format!("Failed to query node_status for node {node_id}: {e}"),
-        })
+    Ok(get_node_status(store, node_id)
+        .await?
+        .and_then(|status| status.performance))
 }

--- a/crates/unet-core/src/datastore/sqlite/derived_state_history.rs
+++ b/crates/unet-core/src/datastore/sqlite/derived_state_history.rs
@@ -1,0 +1,220 @@
+//! Derived-state snapshot storage and history queries for the `SQLite` datastore.
+
+use super::SqliteStore;
+use super::conversions::entity_to_node_status;
+use crate::datastore::{DataStoreError, DataStoreResult, HistoryQueryOptions};
+use crate::entities::{interface_status, node_status};
+use crate::models::derived::{InterfaceAdminStatus, InterfaceOperStatus, NodeStatus};
+use chrono::{SecondsFormat, Utc};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    TransactionTrait,
+};
+use std::collections::HashMap;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+pub async fn store_node_status_snapshot(
+    store: &SqliteStore,
+    snapshot: &NodeStatus,
+) -> DataStoreResult<()> {
+    let txn = store
+        .db
+        .begin()
+        .await
+        .map_err(|e| DataStoreError::TransactionError {
+            message: format!("Failed to begin derived-state snapshot transaction: {e}"),
+        })?;
+    let snapshot_id = Uuid::new_v4().to_string();
+
+    node_status::ActiveModel {
+        id: Set(snapshot_id.clone()),
+        node_id: Set(snapshot.node_id.to_string()),
+        last_updated: Set(format_timestamp(snapshot.last_updated)),
+        reachable: Set(snapshot.reachable),
+        system_info: Set(serialize_optional_json(snapshot.system_info.as_ref())?),
+        performance: Set(serialize_optional_json(snapshot.performance.as_ref())?),
+        environmental: Set(serialize_optional_json(snapshot.environmental.as_ref())?),
+        vendor_metrics: Set(serialize_map_json(&snapshot.vendor_metrics)?),
+        raw_snmp_data: Set(serialize_map_json(&snapshot.raw_snmp_data)?),
+        last_snmp_success: Set(snapshot.last_snmp_success.map(format_timestamp)),
+        last_error: Set(snapshot.last_error.clone()),
+        consecutive_failures: Set(i32::try_from(snapshot.consecutive_failures).map_err(|e| {
+            DataStoreError::ValidationError {
+                message: format!("Invalid consecutive failure count: {e}"),
+            }
+        })?),
+    }
+    .insert(&txn)
+    .await
+    .map_err(|e| DataStoreError::InternalError {
+        message: format!(
+            "Failed to insert node_status snapshot for {}: {e}",
+            snapshot.node_id
+        ),
+    })?;
+
+    for interface in &snapshot.interfaces {
+        interface_status::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            node_status_id: Set(snapshot_id.clone()),
+            index: Set(i32::try_from(interface.index).map_err(|e| {
+                DataStoreError::ValidationError {
+                    message: format!("Invalid interface index: {e}"),
+                }
+            })?),
+            name: Set(interface.name.clone()),
+            interface_type: Set(i32::try_from(interface.interface_type).map_err(|e| {
+                DataStoreError::ValidationError {
+                    message: format!("Invalid interface type: {e}"),
+                }
+            })?),
+            mtu: Set(interface.mtu.map(i32::try_from).transpose().map_err(|e| {
+                DataStoreError::ValidationError {
+                    message: format!("Invalid interface MTU: {e}"),
+                }
+            })?),
+            speed: Set(interface
+                .speed
+                .map(i64::try_from)
+                .transpose()
+                .map_err(|e| DataStoreError::ValidationError {
+                    message: format!("Invalid interface speed: {e}"),
+                })?),
+            physical_address: Set(interface.physical_address.clone()),
+            admin_status: Set(admin_status_value(interface.admin_status).to_string()),
+            oper_status: Set(oper_status_value(interface.oper_status).to_string()),
+            last_change: Set(interface
+                .last_change
+                .map(i32::try_from)
+                .transpose()
+                .map_err(|e| DataStoreError::ValidationError {
+                    message: format!("Invalid interface last_change: {e}"),
+                })?),
+            input_stats: Set(serialize_required_json(&interface.input_stats)?),
+            output_stats: Set(serialize_required_json(&interface.output_stats)?),
+        }
+        .insert(&txn)
+        .await
+        .map_err(|e| DataStoreError::InternalError {
+            message: format!(
+                "Failed to insert interface snapshot {} for {}: {e}",
+                interface.name, snapshot.node_id
+            ),
+        })?;
+    }
+
+    txn.commit()
+        .await
+        .map_err(|e| DataStoreError::TransactionError {
+            message: format!("Failed to commit derived-state snapshot transaction: {e}"),
+        })
+}
+
+pub async fn get_node_status_history(
+    store: &SqliteStore,
+    node_id: &Uuid,
+    options: &HistoryQueryOptions,
+) -> DataStoreResult<Vec<NodeStatus>> {
+    let mut query = node_status::Entity::find()
+        .filter(node_status::Column::NodeId.eq(node_id.to_string()))
+        .order_by_desc(node_status::Column::LastUpdated);
+
+    if let Some(since) = options.since {
+        query = query.filter(node_status::Column::LastUpdated.gte(format_timestamp(since)));
+    }
+    if options.limit > 0 {
+        query = query.limit(options.limit as u64);
+    }
+
+    let status_entities =
+        query
+            .all(&store.db)
+            .await
+            .map_err(|e| DataStoreError::InternalError {
+                message: format!("Failed to query node_status history for node {node_id}: {e}"),
+            })?;
+    if status_entities.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let interface_entities = interface_status::Entity::find()
+        .filter(
+            interface_status::Column::NodeStatusId
+                .is_in(status_entities.iter().map(|status| status.id.clone())),
+        )
+        .order_by_asc(interface_status::Column::Index)
+        .all(&store.db)
+        .await
+        .map_err(|e| DataStoreError::InternalError {
+            message: format!("Failed to query interface history for node {node_id}: {e}"),
+        })?;
+
+    let mut interfaces_by_status: HashMap<String, Vec<interface_status::Model>> = HashMap::new();
+    for interface in interface_entities {
+        interfaces_by_status
+            .entry(interface.node_status_id.clone())
+            .or_default()
+            .push(interface);
+    }
+
+    status_entities
+        .into_iter()
+        .map(|status| {
+            let interfaces = interfaces_by_status.remove(&status.id).unwrap_or_default();
+            entity_to_node_status(status, interfaces)
+        })
+        .collect()
+}
+
+fn serialize_required_json<T>(value: &T) -> DataStoreResult<String>
+where
+    T: serde::Serialize,
+{
+    serde_json::to_string(value).map_err(|e| DataStoreError::InternalError {
+        message: format!("Failed to serialize derived-state JSON: {e}"),
+    })
+}
+
+fn serialize_optional_json<T>(value: Option<&T>) -> DataStoreResult<Option<String>>
+where
+    T: serde::Serialize,
+{
+    value.map(serialize_required_json).transpose()
+}
+
+fn serialize_map_json<T>(value: &HashMap<String, T>) -> DataStoreResult<Option<String>>
+where
+    T: serde::Serialize,
+{
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        serialize_required_json(value).map(Some)
+    }
+}
+
+fn format_timestamp(value: SystemTime) -> String {
+    chrono::DateTime::<Utc>::from(value).to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+const fn admin_status_value(value: InterfaceAdminStatus) -> &'static str {
+    match value {
+        InterfaceAdminStatus::Up => "up",
+        InterfaceAdminStatus::Down => "down",
+        InterfaceAdminStatus::Testing => "testing",
+        InterfaceAdminStatus::Unknown => "unknown",
+    }
+}
+
+const fn oper_status_value(value: InterfaceOperStatus) -> &'static str {
+    match value {
+        InterfaceOperStatus::Up => "up",
+        InterfaceOperStatus::Down => "down",
+        InterfaceOperStatus::Testing => "testing",
+        InterfaceOperStatus::Unknown => "unknown",
+        InterfaceOperStatus::Dormant => "dormant",
+        InterfaceOperStatus::NotPresent => "notPresent",
+        InterfaceOperStatus::LowerLayerDown => "lowerLayerDown",
+    }
+}

--- a/crates/unet-core/src/datastore/sqlite/metadata.rs
+++ b/crates/unet-core/src/datastore/sqlite/metadata.rs
@@ -6,7 +6,7 @@ use crate::entities::{
     interface_status, links, locations, node_status, nodes, polling_tasks, vendors,
 };
 use sea_orm::{ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub async fn get_entity_counts(store: &SqliteStore) -> DataStoreResult<HashMap<String, usize>> {
     let mut counts = HashMap::new();
@@ -59,25 +59,18 @@ pub async fn get_statistics(
     store: &SqliteStore,
 ) -> DataStoreResult<HashMap<String, serde_json::Value>> {
     let counts = get_entity_counts(store).await?;
-    let nodes_with_status = *counts.get("node_status").unwrap_or(&0);
-    let interfaces_monitored = *counts.get("interface_status").unwrap_or(&0);
-    let reachable_nodes = node_status::Entity::find()
-        .filter(node_status::Column::Reachable.eq(true))
-        .count(&store.db)
-        .await
-        .map_err(|e| DataStoreError::InternalError {
-            message: format!("Failed to count reachable node_status rows: {e}"),
-        })?
-        .try_into()
-        .unwrap_or(usize::MAX);
-    let latest_status_update = node_status::Entity::find()
-        .order_by_desc(node_status::Column::LastUpdated)
-        .one(&store.db)
-        .await
-        .map_err(|e| DataStoreError::InternalError {
-            message: format!("Failed to query latest node_status row: {e}"),
-        })?
-        .map(|model| model.last_updated);
+    let latest_snapshots = latest_status_rows(store).await?;
+    let nodes_with_status = latest_snapshots.len();
+    let reachable_nodes = latest_snapshots
+        .iter()
+        .filter(|snapshot| snapshot.reachable)
+        .count();
+    let latest_status_update = latest_snapshots
+        .iter()
+        .map(|snapshot| snapshot.last_updated.as_str())
+        .max()
+        .map(ToOwned::to_owned);
+    let interfaces_monitored = count_latest_interfaces(store, &latest_snapshots).await?;
 
     let mut stats = HashMap::new();
     stats.insert("datastore".to_string(), serde_json::Value::from("sqlite"));
@@ -117,4 +110,45 @@ fn count_query(result: Result<u64, sea_orm::DbErr>, label: &str) -> DataStoreRes
         .map_err(|e| DataStoreError::InternalError {
             message: format!("Failed to convert count for {label}: {e}"),
         })
+}
+
+async fn latest_status_rows(store: &SqliteStore) -> DataStoreResult<Vec<node_status::Model>> {
+    let rows = node_status::Entity::find()
+        .order_by_asc(node_status::Column::NodeId)
+        .order_by_desc(node_status::Column::LastUpdated)
+        .all(&store.db)
+        .await
+        .map_err(|e| DataStoreError::InternalError {
+            message: format!("Failed to query latest node_status rows: {e}"),
+        })?;
+    let mut seen_node_ids = HashSet::new();
+    let mut latest_rows = Vec::new();
+
+    for row in rows {
+        if seen_node_ids.insert(row.node_id.clone()) {
+            latest_rows.push(row);
+        }
+    }
+
+    Ok(latest_rows)
+}
+
+async fn count_latest_interfaces(
+    store: &SqliteStore,
+    latest_snapshots: &[node_status::Model],
+) -> DataStoreResult<usize> {
+    if latest_snapshots.is_empty() {
+        return Ok(0);
+    }
+
+    count_query(
+        interface_status::Entity::find()
+            .filter(
+                interface_status::Column::NodeStatusId
+                    .is_in(latest_snapshots.iter().map(|snapshot| snapshot.id.clone())),
+            )
+            .count(&store.db)
+            .await,
+        "latest interface_status",
+    )
 }

--- a/crates/unet-core/src/datastore/sqlite/mod.rs
+++ b/crates/unet-core/src/datastore/sqlite/mod.rs
@@ -5,6 +5,7 @@ pub use transaction::SqliteTransaction;
 
 mod conversions;
 mod derived_state;
+mod derived_state_history;
 mod filters;
 mod links;
 mod locations;

--- a/crates/unet-core/src/datastore/sqlite/store.rs
+++ b/crates/unet-core/src/datastore/sqlite/store.rs
@@ -1,11 +1,11 @@
 //! Main `SQLite` store implementation
 
-use super::{derived_state, links, locations, metadata, nodes, vendors};
+use super::{derived_state, derived_state_history, links, locations, metadata, nodes, vendors};
 
 use super::super::DataStore;
 use super::super::types::{
-    BatchOperation, BatchResult, DataStoreError, DataStoreResult, PagedResult, QueryOptions,
-    Transaction,
+    BatchOperation, BatchResult, DataStoreError, DataStoreResult, HistoryQueryOptions, PagedResult,
+    QueryOptions, Transaction,
 };
 use super::transaction::SqliteTransaction;
 use crate::models::derived::{InterfaceStatus, NodeStatus, PerformanceMetrics};
@@ -231,6 +231,18 @@ impl DataStore for SqliteStore {
         node_id: &Uuid,
     ) -> DataStoreResult<Option<PerformanceMetrics>> {
         derived_state::get_node_metrics(self, node_id).await
+    }
+
+    async fn store_node_status_snapshot(&self, snapshot: &NodeStatus) -> DataStoreResult<()> {
+        derived_state_history::store_node_status_snapshot(self, snapshot).await
+    }
+
+    async fn get_node_status_history(
+        &self,
+        node_id: &Uuid,
+        options: &HistoryQueryOptions,
+    ) -> DataStoreResult<Vec<NodeStatus>> {
+        derived_state_history::get_node_status_history(self, node_id, options).await
     }
 }
 

--- a/crates/unet-core/src/datastore/sqlite/store/derived_state_tests.rs
+++ b/crates/unet-core/src/datastore/sqlite/store/derived_state_tests.rs
@@ -3,8 +3,16 @@
 use super::super::SqliteStore;
 use crate::datastore::DataStore;
 use crate::entities;
+use crate::models::derived::{
+    InterfaceAdminStatus, InterfaceOperStatus, InterfaceStats, InterfaceStatus, NodeStatus,
+    PerformanceMetrics, SystemInfo,
+};
 use crate::models::{DeviceRole, Node, Vendor};
+use chrono::{DateTime, Utc};
+use migration::Migrator;
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Database, DatabaseBackend, Schema, Set};
+use sea_orm_migration::MigratorTrait;
+use std::time::SystemTime;
 
 fn test_node() -> Node {
     Node::new(
@@ -39,6 +47,81 @@ async fn apply_entity_schema(connection: &impl ConnectionTrait) {
             .execute(connection.get_database_backend().build(&stmt))
             .await
             .unwrap();
+    }
+}
+
+async fn setup_migrated_store() -> SqliteStore {
+    let store = SqliteStore::new("sqlite::memory:").await.unwrap();
+    Migrator::up(store.connection(), None).await.unwrap();
+    store
+}
+
+fn parse_timestamp(value: &str) -> SystemTime {
+    DateTime::parse_from_rfc3339(value)
+        .unwrap()
+        .with_timezone(&Utc)
+        .into()
+}
+
+fn snapshot(
+    node_id: uuid::Uuid,
+    last_updated: &str,
+    reachable: bool,
+    name: &str,
+    oper_status: InterfaceOperStatus,
+    cpu: u8,
+) -> NodeStatus {
+    NodeStatus {
+        node_id,
+        last_updated: parse_timestamp(last_updated),
+        reachable,
+        system_info: Some(SystemInfo {
+            description: Some(format!("{name} chassis")),
+            object_id: None,
+            uptime_ticks: Some(12_345),
+            contact: None,
+            name: Some(name.to_string()),
+            location: Some("rack-1".to_string()),
+            services: Some(72),
+        }),
+        interfaces: vec![InterfaceStatus {
+            index: 1,
+            name: "GigabitEthernet0/1".to_string(),
+            interface_type: 6,
+            mtu: Some(1500),
+            speed: Some(1_000_000_000),
+            physical_address: Some("00:11:22:33:44:55".to_string()),
+            admin_status: InterfaceAdminStatus::Up,
+            oper_status,
+            last_change: Some(10),
+            input_stats: InterfaceStats {
+                octets: 1000,
+                packets: 10,
+                errors: 0,
+                discards: 0,
+            },
+            output_stats: InterfaceStats {
+                octets: 2000,
+                packets: 20,
+                errors: 0,
+                discards: 0,
+            },
+        }],
+        performance: Some(PerformanceMetrics {
+            cpu_utilization: Some(cpu),
+            memory_utilization: Some(70),
+            total_memory: Some(8192),
+            used_memory: Some(4096),
+            load_average: Some(0.5),
+        }),
+        environmental: None,
+        vendor_metrics: std::collections::HashMap::new(),
+        raw_snmp_data: std::collections::HashMap::new(),
+        last_snmp_success: Some(parse_timestamp(last_updated)),
+        last_error: reachable
+            .then(String::new)
+            .filter(|value| !value.is_empty()),
+        consecutive_failures: if reachable { 0 } else { 2 },
     }
 }
 
@@ -200,4 +283,121 @@ async fn test_get_node_metrics_returns_none_without_persisted_status() {
 
     let metrics = store.get_node_metrics(&node.id).await.unwrap();
     assert!(metrics.is_none());
+}
+
+#[tokio::test]
+async fn test_store_node_status_snapshot_supports_history_queries_after_migrations() {
+    let store = setup_migrated_store().await;
+    let node = test_node();
+    store.create_node(&node).await.unwrap();
+
+    let older = snapshot(
+        node.id,
+        "2026-04-07T01:00:00Z",
+        false,
+        "derived-node-old",
+        InterfaceOperStatus::Down,
+        15,
+    );
+    let newer = snapshot(
+        node.id,
+        "2026-04-07T02:00:00Z",
+        true,
+        "derived-node-new",
+        InterfaceOperStatus::Up,
+        55,
+    );
+
+    store.store_node_status_snapshot(&older).await.unwrap();
+    store.store_node_status_snapshot(&newer).await.unwrap();
+
+    let latest = store.get_node_status(&node.id).await.unwrap().unwrap();
+    assert!(latest.reachable);
+    assert_eq!(
+        latest.system_info.unwrap().name.as_deref(),
+        Some("derived-node-new")
+    );
+    assert_eq!(latest.interfaces[0].oper_status, InterfaceOperStatus::Up);
+
+    let history = store
+        .get_node_status_history(
+            &node.id,
+            &crate::datastore::HistoryQueryOptions {
+                limit: 10,
+                since: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(history.len(), 2);
+    assert_eq!(
+        history[0].system_info.as_ref().unwrap().name.as_deref(),
+        Some("derived-node-new")
+    );
+    assert_eq!(
+        history[1].system_info.as_ref().unwrap().name.as_deref(),
+        Some("derived-node-old")
+    );
+
+    let metrics = store.get_node_metrics(&node.id).await.unwrap().unwrap();
+    assert_eq!(metrics.cpu_utilization, Some(55));
+}
+
+#[tokio::test]
+async fn test_get_node_status_history_applies_limit_and_since_filter() {
+    let store = setup_migrated_store().await;
+    let node = test_node();
+    store.create_node(&node).await.unwrap();
+
+    for (timestamp, reachable, cpu) in [
+        ("2026-04-07T01:00:00Z", false, 10),
+        ("2026-04-07T02:00:00Z", true, 20),
+        ("2026-04-07T03:00:00Z", true, 30),
+    ] {
+        let snapshot = snapshot(
+            node.id,
+            timestamp,
+            reachable,
+            "derived-node-filter",
+            InterfaceOperStatus::Up,
+            cpu,
+        );
+        store.store_node_status_snapshot(&snapshot).await.unwrap();
+    }
+
+    let limited = store
+        .get_node_status_history(
+            &node.id,
+            &crate::datastore::HistoryQueryOptions {
+                limit: 1,
+                since: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(limited.len(), 1);
+    assert_eq!(
+        limited[0].performance.as_ref().unwrap().cpu_utilization,
+        Some(30)
+    );
+
+    let filtered = store
+        .get_node_status_history(
+            &node.id,
+            &crate::datastore::HistoryQueryOptions {
+                limit: 10,
+                since: Some(parse_timestamp("2026-04-07T01:30:00Z")),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(filtered.len(), 2);
+    assert_eq!(
+        filtered[0].performance.as_ref().unwrap().cpu_utilization,
+        Some(30)
+    );
+    assert_eq!(
+        filtered[1].performance.as_ref().unwrap().cpu_utilization,
+        Some(20)
+    );
 }

--- a/crates/unet-core/src/datastore/sqlite/store/metadata_tests.rs
+++ b/crates/unet-core/src/datastore/sqlite/store/metadata_tests.rs
@@ -220,3 +220,100 @@ async fn test_get_statistics_returns_null_latest_status_without_status_rows() {
     assert_eq!(stats.get("unreachable_nodes").unwrap(), &Value::from(0));
     assert_eq!(stats.get("latest_status_update").unwrap(), &Value::Null);
 }
+
+#[tokio::test]
+async fn test_get_statistics_uses_latest_snapshot_per_node_for_counts() {
+    let store = setup_schema_store().await;
+    let flapping = Node::new(
+        "flapping-node".to_string(),
+        "example.com".to_string(),
+        Vendor::Cisco,
+        DeviceRole::Router,
+    );
+    let stable = Node::new(
+        "stable-node".to_string(),
+        "example.com".to_string(),
+        Vendor::Cisco,
+        DeviceRole::Router,
+    );
+    store.create_node(&flapping).await.unwrap();
+    store.create_node(&stable).await.unwrap();
+
+    for (id, node_id, last_updated, reachable) in [
+        (
+            "status-flapping-old",
+            flapping.id.to_string(),
+            "2026-04-07T01:00:00Z",
+            false,
+        ),
+        (
+            "status-flapping-new",
+            flapping.id.to_string(),
+            "2026-04-07T02:00:00Z",
+            true,
+        ),
+        (
+            "status-stable",
+            stable.id.to_string(),
+            "2026-04-07T03:00:00Z",
+            false,
+        ),
+    ] {
+        crate::entities::node_status::ActiveModel {
+            id: sea_orm::Set(id.to_string()),
+            node_id: sea_orm::Set(node_id),
+            last_updated: sea_orm::Set(last_updated.to_string()),
+            reachable: sea_orm::Set(reachable),
+            system_info: sea_orm::Set(None),
+            performance: sea_orm::Set(None),
+            environmental: sea_orm::Set(None),
+            vendor_metrics: sea_orm::Set(None),
+            raw_snmp_data: sea_orm::Set(None),
+            last_snmp_success: sea_orm::Set(None),
+            last_error: sea_orm::Set(None),
+            consecutive_failures: sea_orm::Set(0),
+        }
+        .insert(store.connection())
+        .await
+        .unwrap();
+    }
+
+    for (id, node_status_id, index, oper_status) in [
+        ("iface-old", "status-flapping-old", 1, "down"),
+        ("iface-new", "status-flapping-new", 2, "up"),
+        ("iface-stable", "status-stable", 7, "down"),
+    ] {
+        crate::entities::interface_status::ActiveModel {
+            id: sea_orm::Set(id.to_string()),
+            node_status_id: sea_orm::Set(node_status_id.to_string()),
+            index: sea_orm::Set(index),
+            name: sea_orm::Set(format!("GigabitEthernet0/{index}")),
+            interface_type: sea_orm::Set(6),
+            mtu: sea_orm::Set(Some(1500)),
+            speed: sea_orm::Set(Some(1_000_000_000)),
+            physical_address: sea_orm::Set(None),
+            admin_status: sea_orm::Set("up".to_string()),
+            oper_status: sea_orm::Set(oper_status.to_string()),
+            last_change: sea_orm::Set(None),
+            input_stats: sea_orm::Set(
+                r#"{"octets":1000,"packets":10,"errors":0,"discards":0}"#.to_string(),
+            ),
+            output_stats: sea_orm::Set(
+                r#"{"octets":2000,"packets":20,"errors":0,"discards":0}"#.to_string(),
+            ),
+        }
+        .insert(store.connection())
+        .await
+        .unwrap();
+    }
+
+    let stats = store.get_statistics().await.unwrap();
+    assert_eq!(stats.get("nodes_with_status").unwrap(), &Value::from(2));
+    assert_eq!(stats.get("reachable_nodes").unwrap(), &Value::from(1));
+    assert_eq!(stats.get("unreachable_nodes").unwrap(), &Value::from(1));
+    assert_eq!(stats.get("interfaces_monitored").unwrap(), &Value::from(2));
+    assert_eq!(
+        stats.get("latest_status_update").unwrap(),
+        &Value::from("2026-04-07T03:00:00Z")
+    );
+}

--- a/crates/unet-core/src/datastore/tests/trait_method_tests.rs
+++ b/crates/unet-core/src/datastore/tests/trait_method_tests.rs
@@ -171,6 +171,42 @@ async fn test_get_node_metrics_default_implementation() {
 }
 
 #[tokio::test]
+async fn test_store_node_status_snapshot_default_implementation() {
+    let datastore = MockDataStore::new();
+    let snapshot = crate::models::derived::NodeStatus::new(Uuid::new_v4());
+
+    let result = datastore.store_node_status_snapshot(&snapshot).await;
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        DataStoreError::UnsupportedOperation { operation } => {
+            assert_eq!(operation, "store_node_status_snapshot");
+        }
+        other => panic!("Expected UnsupportedOperation error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_node_status_history_default_implementation() {
+    let datastore = MockDataStore::new();
+    let node_id = Uuid::new_v4();
+    let options = crate::datastore::HistoryQueryOptions {
+        limit: 10,
+        since: None,
+    };
+
+    let result = datastore.get_node_status_history(&node_id, &options).await;
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        DataStoreError::UnsupportedOperation { operation } => {
+            assert_eq!(operation, "get_node_status_history");
+        }
+        other => panic!("Expected UnsupportedOperation error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_store_policy_result_default_implementation() {
     let datastore = MockDataStore::new();
     let node_id = Uuid::new_v4();

--- a/crates/unet-core/src/datastore/types.rs
+++ b/crates/unet-core/src/datastore/types.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
 use uuid::Uuid;
 
 /// Errors that can occur during datastore operations
@@ -201,6 +202,15 @@ pub struct QueryOptions {
     pub sort: Vec<Sort>,
     /// Pagination parameters
     pub pagination: Option<Pagination>,
+}
+
+/// Query parameters for derived-state history lookups.
+#[derive(Debug, Clone)]
+pub struct HistoryQueryOptions {
+    /// Maximum number of snapshots to return, newest first.
+    pub limit: usize,
+    /// Optional lower bound for `last_updated`.
+    pub since: Option<SystemTime>,
 }
 
 /// Result of a paginated query

--- a/docs/src/cli_reference.md
+++ b/docs/src/cli_reference.md
@@ -180,7 +180,33 @@ unet nodes metrics router-01
 
 - `<NODE_ID>` - Node name or UUID
 
-**Note:** Historical metrics are not yet implemented.
+**Note:** For historical metrics, use `unet nodes history <NODE_ID> metrics`.
+
+#### `unet nodes history`
+
+Display derived-state history snapshots for a node from the local datastore.
+
+```bash
+unet nodes history router-01
+unet nodes history router-01 metrics --last-hours 24
+unet nodes history router-01 all --detailed
+```
+
+**Arguments:**
+
+- `<NODE_ID>` - Node UUID
+- `[HISTORY_TYPE]` - Optional history view: `status`, `interfaces`, `metrics`, `system`, or `all`
+
+**Options:**
+
+- `-l, --limit <COUNT>` - Maximum number of snapshots to return (newest first)
+- `--last-hours <HOURS>` - Filter to snapshots updated within the last N hours
+- `--detailed` - Include fuller per-snapshot payloads (interfaces, metrics, vendor/raw data where applicable)
+
+**Notes:**
+
+- History is backed by local datastore snapshots from `node_status` and `interface_status`.
+- Remote mode still does not support `unet nodes history`.
 
 ---
 
@@ -596,7 +622,8 @@ unet import backup/
 
 - **Template engine**: Not yet implemented (planned for v0.2.0)
 - **SNMP polling controls**: Background polling runs automatically, but CLI controls are not implemented
-- **Node comparison and history**: Planned for future versions
+- **Node comparison**: Planned for a future version
+- **Remote node history**: `unet nodes history` currently works only against the local datastore
 - **Table output formatting**: Currently defaults to JSON format
 - **Advanced filtering**: jq-style filters not yet implemented
 

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -24,10 +24,10 @@ This document outlines the planned features and release timeline for μNet.
 
 - **SNMP Polling Controls**: CLI commands to manage background polling
 - **Device Discovery**: Automatic capability detection
-- **Historical Metrics**: Time-series data storage and retrieval
+- **Historical Metrics**: Continue expanding time-series storage and retrieval beyond the local datastore-backed `unet nodes history <node-id> metrics --last-hours 24` surface
 - **CLI Commands** (planned):
   - `unet nodes polling start/stop/status`
-  - `unet nodes history --metrics --since 1d`
+  - `unet nodes history <node-id> metrics --last-hours 24`
   - `unet nodes compare <node1> <node2>`
 
 ### **Milestone 6: Configuration Push**


### PR DESCRIPTION
## Summary
- store append-only derived-state snapshots so node status history can be queried from the local datastore
- replace `unet nodes history` placeholder payloads with real `status`, `interfaces`, `metrics`, `system`, and `all` history views
- keep current statistics on latest-snapshot semantics and document the supported local history surface plus explicit remote limitation

## Testing
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0 -C codegen-units=1' cargo test -p unet-core --lib test_store_node_status_snapshot_supports_history_queries_after_migrations -- --nocapture`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0 -C codegen-units=1' cargo test -p unet-core --lib test_get_node_status_history_applies_limit_and_since_filter -- --nocapture`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0 -C codegen-units=1' cargo test -p unet-core --lib test_get_statistics_uses_latest_snapshot_per_node_for_counts -- --nocapture`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0 -C codegen-units=1' cargo test -p unet-core --lib test_store_node_status_snapshot_default_implementation -- --nocapture`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0 -C codegen-units=1' cargo test -p unet-core --lib test_get_node_status_history_default_implementation -- --nocapture`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0 -C codegen-units=1' cargo test -p unet-cli --lib test_build_history_output_uses_real_snapshots_for_all_supported_types -- --nocapture`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0 -C codegen-units=1' cargo test -p unet-cli --lib test_history_all_variants -- --nocapture`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0 -C codegen-units=1' cargo clippy -p unet-core -p unet-cli --lib -- -D warnings`
- `bash scripts/check-large-files.sh`

## Notes
- full package-test `clippy` still hits a pre-existing unrelated `clippy::similar_names` failure in `crates/unet-core/src/datastore/sqlite/conversions_tests.rs`
- `unet nodes history` remains local-datastore only; remote history still returns an explicit unsupported error path
