### PR TITLE
Track real policy evaluation metadata in policy status

### DIFF
--- a/crates/unet-server/src/handlers/nodes/crud_tests.rs
+++ b/crates/unet-server/src/handlers/nodes/crud_tests.rs
@@ -54,7 +54,7 @@ pub mod test_utils {
         }
     }
 
-    /// Set up a test app state together with the underlying SQLite connection.
+    /// Set up a test app state together with the underlying `SQLite` connection.
     pub async fn setup_test_app_state_with_connection() -> (DatabaseConnection, AppState) {
         let store = sqlite_store().await;
         let connection = store.connection().clone();

--- a/crates/unet-server/src/handlers/policies/response_handling.rs
+++ b/crates/unet-server/src/handlers/policies/response_handling.rs
@@ -46,6 +46,7 @@ pub async fn evaluate_policies(
         request.store_results.unwrap_or(true),
     )
     .await;
+    policy_service.record_evaluation_run();
 
     let evaluation_time = start_time.elapsed();
     log_evaluation_completion(&nodes, &policies, evaluation_time);
@@ -95,15 +96,17 @@ mod tests {
     use std::fs;
     use std::sync::Arc;
     use tempfile::TempDir;
+    use test_support::sqlite::sqlite_store;
     use unet_core::{
         datastore::{DataStore, sqlite::SqliteStore},
         models::*,
         policy::{Action, ComparisonOperator, Condition, FieldRef, PolicyRule, Value},
         policy_integration::PolicyService,
     };
-    use test_support::sqlite::sqlite_store;
 
-    async fn setup_test_datastore() -> SqliteStore { sqlite_store().await }
+    async fn setup_test_datastore() -> SqliteStore {
+        sqlite_store().await
+    }
 
     async fn create_test_node(datastore: &SqliteStore) -> Node {
         let mut node = Node::new(
@@ -185,7 +188,8 @@ WHEN node.vendor == "cisco" THEN ASSERT node.version IS "15.1"
 
             let response = result.unwrap().0;
             assert_eq!(response.nodes_evaluated, 1);
-        }).await;
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -335,7 +339,8 @@ WHEN node.vendor == "cisco" THEN ASSERT node.version IS "15.1"
 
             let response = result.unwrap().0;
             assert_eq!(response.nodes_evaluated, 1);
-        }).await;
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/crates/unet-server/src/handlers/policies/status.rs
+++ b/crates/unet-server/src/handlers/policies/status.rs
@@ -49,12 +49,19 @@ pub async fn get_policy_status(
 
 #[cfg(test)]
 mod tests {
+    use super::super::{response_handling::evaluate_policies, types::PolicyEvaluationRequest};
     use super::*;
     use crate::server::AppState;
+    use migration::{Migrator, MigratorTrait};
+    use std::fs;
     use std::sync::Arc;
-    use unet_core::{datastore::DataStore, models::*, policy_integration::PolicyService};
+    use unet_core::{
+        datastore::{DataStore, sqlite::SqliteStore},
+        models::*,
+        policy_integration::PolicyService,
+    };
 
-    async fn create_test_node(datastore: &dyn DataStore) -> Node {
+    async fn create_test_node(datastore: &SqliteStore) -> Node {
         let mut node = Node::new(
             "test-node".to_string(),
             "example.com".to_string(),
@@ -64,6 +71,12 @@ mod tests {
         node.model = "ASR1000".to_string();
         node.lifecycle = Lifecycle::Live;
         datastore.create_node(&node).await.unwrap()
+    }
+
+    async fn setup_isolated_test_datastore() -> SqliteStore {
+        let store = SqliteStore::new("sqlite::memory:").await.unwrap();
+        Migrator::up(store.connection(), None).await.unwrap();
+        store
     }
 
     #[tokio::test]
@@ -106,5 +119,34 @@ mod tests {
             assert!(chrono::DateTime::parse_from_rfc3339(last_evaluation).is_ok());
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_policy_status_reports_last_evaluation_after_on_demand_evaluation() {
+        let store = setup_isolated_test_datastore().await;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let policy_file = temp_dir.path().join("test.policy");
+        fs::write(
+            &policy_file,
+            "WHEN node.vendor == \"cisco\" THEN ASSERT node.version IS \"15.1\"\n",
+        )
+        .unwrap();
+        let node = create_test_node(&store).await;
+        let app_state = AppState {
+            datastore: Arc::new(store),
+            policy_service: PolicyService::with_local_dir(temp_dir.path().to_str().unwrap()),
+        };
+        let request = PolicyEvaluationRequest {
+            node_ids: Some(vec![node.id]),
+            policies: None,
+            store_results: Some(false),
+        };
+
+        let evaluation = evaluate_policies(State(app_state.clone()), Json(request)).await;
+        assert!(evaluation.is_ok());
+
+        let response = get_policy_status(State(app_state)).await.unwrap().0;
+        let last_evaluation = response["last_evaluation"].as_str().unwrap();
+        assert!(chrono::DateTime::parse_from_rfc3339(last_evaluation).is_ok());
     }
 }

--- a/docs/src/api_reference.md
+++ b/docs/src/api_reference.md
@@ -500,10 +500,17 @@ Get policy engine status.
   "policy_engine_enabled": true,
   "nodes_available": 25,
   "policies_available": 10,
-  "last_evaluation": null,
-  "evaluation_frequency": "on-demand"
+  "last_evaluation": "2026-04-08T06:52:13Z",
+  "evaluation_frequency": "every 300 seconds",
+  "evaluation_frequency_seconds": 300
 }
 ```
+
+- `last_evaluation` is `null` until the first policy evaluation cycle completes.
+  Successful background and on-demand policy evaluations both update this
+  timestamp.
+- `evaluation_frequency` and `evaluation_frequency_seconds` describe the
+  configured periodic background evaluation schedule.
 
 ---
 


### PR DESCRIPTION
## Summary
- record on-demand policy evaluation runs in shared `PolicyService` runtime status
- add a regression test proving `/api/v1/policies/status` updates after `/api/v1/policies/evaluate`
- update the policy status API reference to show the real response payload and interval semantics
- fix an existing `clippy::doc_markdown` warning in a `unet-server` test helper comment

## Testing
- `CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p unet-server handlers::policies::status::tests --lib -- --test-threads=1`
- `CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p unet-server handlers::policies::response_handling::tests::test_evaluate_policies_all_nodes --lib`
- `RUSTC_WRAPPER= CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo clippy -p unet-server --lib --tests -- -D warnings`
- `rustfmt --edition 2024 --check crates/unet-server/src/handlers/nodes/crud_tests.rs crates/unet-server/src/handlers/policies/response_handling.rs crates/unet-server/src/handlers/policies/status.rs`
- `bash scripts/check-large-files.sh`
