### PR TITLE
BED-35 implement config-slicer parse, slice, and diff CLI

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -7,16 +7,16 @@
 ## Executive Summary
 
 μNet has functional core components with 166 passing tests. The project is ~60%
-complete. Key features like template engine and config-slicer exist only as
-placeholder code.
+complete. Key features like the template engine and Git integration still
+remain planned.
 
 **Current Reality:**
 
 - ✅ **Implemented:** Core models, policy engine, SNMP framework, CLI, API
 - ⚠️ **Missing Integration:** Background tasks, derived state tracking, some
 API endpoints
-- ❌ **Missing Features:** Template engine, config-slicer, Git integration (all
-placeholder code)
+- ⚠️ **Partially Implemented:** `config-slicer` baseline parse/slice/diff CLI
+- ❌ **Missing Features:** Template engine, Git integration (placeholder code)
 
 ## Current Project State
 
@@ -63,9 +63,9 @@ placeholder code)
 
 **Config-Slicer (Milestone 5):**
 
-- Hierarchical diff engine
-- Configuration parsing
-- Diff workflows
+- Baseline hierarchical parsing for `flat` and `junos` inputs
+- Parse, slice, and diff CLI workflows
+- Unified diff output for sliced configuration
 - **Implementation complexity:** Complex
 
 **Git Integration (Milestone 6):**
@@ -94,10 +94,10 @@ placeholder code)
 
 ### 3. **Config-Slicer Implementation** (Complex)
 
-- [ ] Build hierarchical configuration parser
+- [x] Build hierarchical configuration parser
 - [ ] Implement intelligent diff engine
-- [ ] Add configuration comparison workflows
-- [ ] Create CLI commands for diffing operations
+- [x] Add configuration comparison workflows
+- [x] Create CLI commands for parse/slice/diff operations
 - [ ] Add visualization for configuration changes
 
 ### 4. **Git Integration** (Moderate complexity)

--- a/crates/config-slicer/Cargo.toml
+++ b/crates/config-slicer/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { workspace = true }
 clap = { workspace = true }
 
 # Configuration diffing
+regex = { workspace = true }
 similar = { workspace = true }
 
 # Logging and tracing
@@ -44,4 +45,3 @@ assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
 criterion = { workspace = true }
-

--- a/crates/config-slicer/README.md
+++ b/crates/config-slicer/README.md
@@ -1,0 +1,53 @@
+# `config-slicer`
+
+`config-slicer` parses hierarchical match expressions and applies them to
+configuration text so focused slices and diffs can be generated from the
+command line.
+
+## Workflows
+
+### Parse a match expression
+
+```bash
+config-slicer parse --match "system||ntp"
+config-slicer parse --match "system||ntp" --json
+```
+
+### Slice a configuration
+
+Reads from a file when one is provided, otherwise reads from stdin.
+
+```bash
+config-slicer slice --match "system||ntp" running.conf
+cat running.conf | config-slicer slice --match "system||ntp"
+config-slicer slice --match "system||ntp" --vendor junos running.conf
+config-slicer slice --match "system||ntp" --json running.conf
+```
+
+### Diff two configurations
+
+`diff` applies the same match expression to both inputs before generating a
+unified diff.
+
+```bash
+config-slicer diff --match "system||ntp" --source before.conf --target after.conf
+```
+
+## Match expressions
+
+- Use `||` to separate hierarchy levels.
+- Use `*` to match any value at a level.
+- Any other level is compiled as a Rust `regex`.
+
+Examples:
+
+- `system||ntp`
+- `interfaces||ge-.*||unit||0`
+- `routing-options||*`
+
+## Vendor handling
+
+- `autodetect`: choose `junos` when brace-delimited blocks are present, otherwise
+  treat the input as `flat`.
+- `junos`: brace-delimited hierarchy.
+- `flat`: line-oriented configuration such as `set` commands.

--- a/crates/config-slicer/src/diff.rs
+++ b/crates/config-slicer/src/diff.rs
@@ -1,22 +1,30 @@
-//! Configuration diffing
+//! Configuration diffing.
 
-/// Placeholder for config diffing - will be implemented in Milestone 5
-pub mod placeholder {
-    /// Placeholder function
-    #[inline]
-    pub const fn placeholder() {
-        // Implementation pending
+use crate::{MatchSpec, Vendor, slice_text};
+use similar::TextDiff;
+
+/// Diff two configurations after slicing them with the same match expression.
+#[must_use]
+pub fn diff_text(source: &str, target: &str, spec: &MatchSpec, vendor: Vendor) -> String {
+    let source_lines = slice_text(source, spec, vendor);
+    let target_lines = slice_text(target, spec, vendor);
+    let source = normalize_for_diff(&source_lines);
+    let target = normalize_for_diff(&target_lines);
+
+    if source == target {
+        return String::new();
     }
+
+    TextDiff::from_lines(&source, &target)
+        .unified_diff()
+        .header("source", "target")
+        .to_string()
 }
 
-#[cfg(test)]
-mod tests {
-    // Arrange-Act-Assert: exercise the placeholder path for coverage
-    #[test]
-    fn test_placeholder_diff() {
-        super::placeholder::placeholder();
-        assert!(true);
+fn normalize_for_diff(lines: &[String]) -> String {
+    let mut rendered = lines.join("\n");
+    if !rendered.is_empty() {
+        rendered.push('\n');
     }
-
-    // Reverted temporary failure used to validate status reporting
+    rendered
 }

--- a/crates/config-slicer/src/error.rs
+++ b/crates/config-slicer/src/error.rs
@@ -1,29 +1,34 @@
 //! Error types for config-slicer
 
+use regex::Error as RegexError;
 use std::io;
 use thiserror::Error;
 
 /// Config-slicer error type
 #[derive(Error, Debug)]
 pub enum ConfigSlicerError {
-    /// Diff error
-    #[error("Diff error: {0}")]
+    /// Diffing failed.
+    #[error("diff error: {0}")]
     Diff(String),
 
-    /// I/O error
+    /// I/O failed.
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
 
-    /// Other error
-    #[error("Other error: {0}")]
-    Other(String),
-
-    /// Parsing error
-    #[error("Parsing error: {0}")]
+    /// Match-expression parsing failed.
+    #[error("invalid match expression: {0}")]
     Parse(String),
 
-    /// Slicing error
-    #[error("Slicing error: {0}")]
+    /// Regex compilation failed.
+    #[error("regex error: {0}")]
+    Regex(#[from] RegexError),
+
+    /// Serialization failed.
+    #[error("serialization error: {0}")]
+    Serialize(#[from] serde_json::Error),
+
+    /// Slicing failed.
+    #[error("slice error: {0}")]
     Slice(String),
 }
 

--- a/crates/config-slicer/src/lib.rs
+++ b/crates/config-slicer/src/lib.rs
@@ -1,39 +1,122 @@
-//! Config-slicer library: exposes CLI parsing and run for reuse in tests/integration.
+//! `config-slicer` library and CLI.
+
+mod diff;
+mod error;
+mod parser;
+mod slicer;
 
 use anyhow::Result;
-use clap::Parser;
-use tracing::{info, warn};
+use clap::{Args, Parser, Subcommand};
+use serde::Serialize;
+use std::fs;
+use std::io::{self, Read};
+use std::path::Path;
+use tracing_subscriber::EnvFilter;
+
+pub use diff::diff_text;
+pub use error::{ConfigSlicerError, Result as ConfigResult};
+pub use parser::{MatchSpec, parse_match};
+pub use slicer::{Vendor, slice_text};
 
 #[derive(Parser, Debug)]
 #[command(name = "config-slicer")]
-#[command(about = "Network configuration slicing and diffing tool")]
+#[command(about = "Parse, slice, and diff configuration text by hierarchical match expression")]
 #[command(version)]
+#[command(arg_required_else_help = true)]
 pub struct Cli {
-    /// Enable verbose logging
-    #[arg(short, long)]
+    /// Enable informational tracing output on stderr.
+    #[arg(short, long, global = true)]
     pub verbose: bool,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Validate a match expression and print its parsed levels.
+    Parse(ParseCommand),
+    /// Slice configuration text from a file or stdin.
+    Slice(SliceCommand),
+    /// Diff two configurations after slicing them with the same match.
+    Diff(DiffCommand),
+}
+
+#[derive(Args, Debug)]
+pub struct ParseCommand {
+    /// Match expression such as `system||ntp`.
+    #[arg(short = 'm', long = "match")]
+    pub match_expression: String,
+
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct SliceCommand {
+    /// Match expression such as `system||ntp`.
+    #[arg(short = 'm', long = "match")]
+    pub match_expression: String,
+
+    /// Input format to parse.
+    #[arg(long, value_enum, default_value_t = Vendor::Autodetect)]
+    pub vendor: Vendor,
+
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Configuration file path. Reads stdin when omitted.
+    pub file: Option<std::path::PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub struct DiffCommand {
+    /// Match expression such as `system||ntp`.
+    #[arg(short = 'm', long = "match")]
+    pub match_expression: String,
+
+    /// Source configuration file.
+    #[arg(long)]
+    pub source: std::path::PathBuf,
+
+    /// Target configuration file.
+    #[arg(long)]
+    pub target: std::path::PathBuf,
+
+    /// Input format to parse.
+    #[arg(long, value_enum, default_value_t = Vendor::Autodetect)]
+    pub vendor: Vendor,
+}
+
+#[derive(Serialize)]
+struct ParsedMatch<'a> {
+    expression: &'a str,
+    levels: &'a [String],
 }
 
 /// Execute the CLI logic with a parsed `Cli`.
 ///
 /// # Errors
-/// Returns an error if initializing logging fails or if downstream operations fail.
+/// Returns an error if a file cannot be read, a match expression is invalid, or
+/// JSON output cannot be rendered.
 pub fn run_with(cli: &Cli) -> Result<()> {
-    // Initialize tracing
-    tracing_subscriber::fmt::init();
+    init_tracing(cli.verbose);
 
-    if cli.verbose {
-        info!("Starting config-slicer CLI in verbose mode");
+    match &cli.command {
+        Command::Parse(command) => run_parse(command)?,
+        Command::Slice(command) => run_slice(command)?,
+        Command::Diff(command) => run_diff(command)?,
     }
 
-    warn!("config-slicer implementation not yet complete");
     Ok(())
 }
 
 /// Parse CLI args and run.
 ///
 /// # Errors
-/// Returns an error from `run_with` if initialization or execution fails.
+/// Returns any execution error from `run_with`.
 pub fn run<I, S>(args: I) -> Result<()>
 where
     I: IntoIterator<Item = S>,
@@ -41,4 +124,72 @@ where
 {
     let cli = Cli::parse_from(args);
     run_with(&cli)
+}
+
+fn init_tracing(verbose: bool) {
+    let default_level = if verbose { "info" } else { "warn" };
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_target(false)
+        .try_init();
+}
+
+fn run_parse(command: &ParseCommand) -> Result<()> {
+    let spec = parse_match(&command.match_expression)?;
+
+    if command.json {
+        println!(
+            "{}",
+            serde_json::to_string(&ParsedMatch {
+                expression: spec.expression(),
+                levels: spec.levels(),
+            })?
+        );
+    } else {
+        for (index, level) in spec.levels().iter().enumerate() {
+            println!("{index}: {level}");
+        }
+    }
+
+    Ok(())
+}
+
+fn run_slice(command: &SliceCommand) -> Result<()> {
+    let spec = parse_match(&command.match_expression)?;
+    let text = read_input(command.file.as_deref())?;
+    let lines = slice_text(&text, &spec, command.vendor);
+
+    if command.json {
+        println!("{}", serde_json::to_string(&lines)?);
+    } else if !lines.is_empty() {
+        println!("{}", lines.join("\n"));
+    }
+
+    Ok(())
+}
+
+fn run_diff(command: &DiffCommand) -> Result<()> {
+    let spec = parse_match(&command.match_expression)?;
+    let source = read_input(Some(command.source.as_path()))?;
+    let target = read_input(Some(command.target.as_path()))?;
+    let diff = diff_text(&source, &target, &spec, command.vendor);
+
+    if !diff.is_empty() {
+        print!("{diff}");
+    }
+
+    Ok(())
+}
+
+fn read_input(path: Option<&Path>) -> io::Result<String> {
+    if let Some(path) = path {
+        fs::read_to_string(path)
+    } else {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer)?;
+        Ok(buffer)
+    }
 }

--- a/crates/config-slicer/src/main.rs
+++ b/crates/config-slicer/src/main.rs
@@ -1,5 +1,8 @@
-//! Configuration Slicer CLI Tool (binary shim)
+//! `config-slicer` binary entrypoint.
 
 fn main() {
-    let _ = config_slicer::run(std::env::args_os());
+    if let Err(error) = config_slicer::run(std::env::args_os()) {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
 }

--- a/crates/config-slicer/src/parser.rs
+++ b/crates/config-slicer/src/parser.rs
@@ -1,19 +1,84 @@
-//! Configuration parsers
+//! Match-expression parsing for `config-slicer`.
 
-/// Placeholder for config parsers - will be implemented in Milestone 5
-pub mod placeholder {
-    /// Placeholder function
-    #[inline]
-    pub const fn placeholder() {
-        // Implementation pending
+use crate::error::{ConfigSlicerError, Result};
+use regex::Regex;
+
+/// Pre-compiled representation of a match expression.
+#[derive(Debug, Clone)]
+pub struct MatchSpec {
+    expression: String,
+    levels: Vec<String>,
+    regexes: Vec<Regex>,
+}
+
+impl MatchSpec {
+    /// Return the original expression.
+    #[must_use]
+    pub fn expression(&self) -> &str {
+        &self.expression
+    }
+
+    /// Return the raw levels from the expression.
+    #[must_use]
+    pub fn levels(&self) -> &[String] {
+        &self.levels
+    }
+
+    #[must_use]
+    pub(crate) fn depth(&self) -> usize {
+        self.regexes.len()
+    }
+
+    pub(crate) fn matches_path_prefix(&self, path: &[String]) -> bool {
+        self.regexes.len() <= path.len()
+            && self
+                .regexes
+                .iter()
+                .zip(path.iter())
+                .all(|(regex, segment)| regex.is_match(segment))
     }
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_placeholder_parser() {
-        super::placeholder::placeholder();
-        assert!(true);
+/// Parse a match expression into a reusable `MatchSpec`.
+///
+/// # Errors
+/// Returns an error when the expression is empty or contains invalid `regex`
+/// syntax at any level.
+pub fn parse_match(expression: &str) -> Result<MatchSpec> {
+    let expression = expression.trim();
+    if expression.is_empty() {
+        return Err(ConfigSlicerError::Parse(
+            "match expression cannot be empty".to_string(),
+        ));
     }
+
+    let levels = expression
+        .split("||")
+        .map(str::trim)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    if levels.iter().any(String::is_empty) {
+        return Err(ConfigSlicerError::Parse(
+            "match expression cannot contain empty levels".to_string(),
+        ));
+    }
+
+    let regexes = levels
+        .iter()
+        .map(|level| {
+            let pattern = if level == "*" {
+                ".*".to_string()
+            } else {
+                level.clone()
+            };
+            Regex::new(&format!("^(?:{pattern})$"))
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(MatchSpec {
+        expression: expression.to_string(),
+        levels,
+        regexes,
+    })
 }

--- a/crates/config-slicer/src/slicer.rs
+++ b/crates/config-slicer/src/slicer.rs
@@ -1,19 +1,144 @@
-//! Configuration slicing
+//! Configuration slicing.
 
-/// Placeholder for config slicing - will be implemented in Milestone 5
-pub mod placeholder {
-    /// Placeholder function
-    #[inline]
-    pub const fn placeholder() {
-        // Implementation pending
+use crate::parser::MatchSpec;
+use clap::ValueEnum;
+use tracing::info;
+
+/// Supported input formats for configuration slicing.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum Vendor {
+    /// Detect the input format from the config text.
+    Autodetect,
+    /// Brace-delimited Junos-style configuration.
+    Junos,
+    /// Flat, line-oriented configuration such as `set` commands.
+    Flat,
+}
+
+/// Slice a configuration string using a parsed match expression.
+#[must_use]
+pub fn slice_text(text: &str, spec: &MatchSpec, vendor: Vendor) -> Vec<String> {
+    match resolve_vendor(text, vendor) {
+        Vendor::Junos => slice_junos(text, spec),
+        Vendor::Flat | Vendor::Autodetect => slice_flat(text, spec),
     }
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_placeholder_slicer() {
-        super::placeholder::placeholder();
-        assert!(true);
+fn resolve_vendor(text: &str, vendor: Vendor) -> Vendor {
+    if vendor != Vendor::Autodetect {
+        return vendor;
+    }
+
+    let resolved = if text
+        .lines()
+        .take(20)
+        .any(|line| line.contains('{') || line.trim_start().starts_with('}'))
+    {
+        Vendor::Junos
+    } else {
+        Vendor::Flat
+    };
+
+    info!("auto-detected vendor as {resolved:?}");
+    resolved
+}
+
+fn slice_flat(text: &str, spec: &MatchSpec) -> Vec<String> {
+    text.lines()
+        .filter_map(|line| {
+            let segments = flat_segments(line);
+            if !segments.is_empty() && spec.matches_path_prefix(&segments) {
+                Some(line.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn flat_segments(line: &str) -> Vec<String> {
+    let trimmed = line.trim();
+    if trimmed.is_empty()
+        || trimmed.starts_with('#')
+        || trimmed.starts_with('!')
+        || trimmed.starts_with("//")
+    {
+        return Vec::new();
+    }
+
+    let normalized = ["set ", "delete ", "activate ", "deactivate "]
+        .iter()
+        .find_map(|prefix| trimmed.strip_prefix(prefix))
+        .unwrap_or(trimmed);
+
+    normalized
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>()
+}
+
+fn slice_junos(text: &str, spec: &MatchSpec) -> Vec<String> {
+    let mut current_path = Vec::new();
+    let mut active_depth = None;
+    let mut output = Vec::new();
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("//") {
+            continue;
+        }
+
+        if trimmed.starts_with('}') {
+            if active_depth.is_some_and(|depth| current_path.len() >= depth) {
+                output.push(line.to_string());
+            }
+
+            if !current_path.is_empty() {
+                current_path.pop();
+            }
+
+            if active_depth.is_some_and(|depth| current_path.len() < depth) {
+                active_depth = None;
+            }
+            continue;
+        }
+
+        let opens_block = trimmed.ends_with('{');
+        let Some(segment) = junos_segment(trimmed) else {
+            continue;
+        };
+
+        let mut candidate_path = current_path.clone();
+        candidate_path.push(segment);
+
+        let line_matches = spec.matches_path_prefix(&candidate_path);
+        let activates_match = line_matches && candidate_path.len() == spec.depth();
+        let inside_match = active_depth
+            .is_some_and(|depth| current_path.len() >= depth && candidate_path.len() > depth);
+
+        if activates_match {
+            active_depth = Some(candidate_path.len());
+            output.push(line.to_string());
+        } else if line_matches || inside_match {
+            output.push(line.to_string());
+        }
+
+        if opens_block {
+            current_path.push(candidate_path.pop().unwrap());
+        } else if activates_match {
+            active_depth = None;
+        }
+    }
+
+    output
+}
+
+fn junos_segment(line: &str) -> Option<String> {
+    let segment = line.trim_end_matches('{').trim_end_matches(';').trim();
+
+    if segment.is_empty() {
+        None
+    } else {
+        Some(segment.to_string())
     }
 }

--- a/crates/config-slicer/tests/check_large_files_script.rs
+++ b/crates/config-slicer/tests/check_large_files_script.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -19,9 +20,10 @@ fn write_rust_file(root: &Path, relative_path: &str, line_count: usize) {
     let file_path = root.join(relative_path);
     fs::create_dir_all(file_path.parent().unwrap()).unwrap();
 
-    let contents = (1..=line_count)
-        .map(|line_number| format!("// line {line_number}\n"))
-        .collect::<String>();
+    let mut contents = String::new();
+    for line_number in 1..=line_count {
+        writeln!(contents, "// line {line_number}").unwrap();
+    }
 
     fs::write(file_path, contents).unwrap();
 }
@@ -32,7 +34,7 @@ fn write_baseline(root: &Path, entries: &[(&str, usize)]) {
 
     let mut contents = String::from("# path\tmax_lines\n");
     for (relative_path, line_count) in entries {
-        contents.push_str(&format!("{relative_path}\t{line_count}\n"));
+        writeln!(contents, "{relative_path}\t{line_count}").unwrap();
     }
 
     fs::write(baseline_path, contents).unwrap();

--- a/crates/config-slicer/tests/cli.rs
+++ b/crates/config-slicer/tests/cli.rs
@@ -33,6 +33,17 @@ fn parse_command_supports_json_output() {
 }
 
 #[test]
+fn parse_command_emits_plain_text_levels() {
+    let mut cmd = Command::cargo_bin("config-slicer").unwrap();
+
+    cmd.args(["parse", "--match", "system||ntp"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0: system"))
+        .stdout(predicate::str::contains("1: ntp"));
+}
+
+#[test]
 fn slice_command_extracts_only_matching_lines() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = write_config(
@@ -55,6 +66,42 @@ fn slice_command_extracts_only_matching_lines() {
             "set system ntp source-address 192.0.2.10",
         ))
         .stdout(predicate::str::contains("set interfaces ge-0/0/0 disable").not());
+}
+
+#[test]
+fn slice_command_supports_json_output() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = write_config(
+        temp_dir.path(),
+        "running.conf",
+        concat!(
+            "set system ntp server 192.0.2.1\n",
+            "set system ntp source-address 192.0.2.10\n",
+        ),
+    );
+
+    let mut cmd = Command::cargo_bin("config-slicer").unwrap();
+
+    cmd.args(["slice", "--match", "system||ntp", "--json", &config_path])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "[\"set system ntp server 192.0.2.1\",\"set system ntp source-address 192.0.2.10\"]",
+        ));
+}
+
+#[test]
+fn slice_command_reads_from_stdin_when_file_is_omitted() {
+    let mut cmd = Command::cargo_bin("config-slicer").unwrap();
+
+    cmd.arg("slice")
+        .arg("--match")
+        .arg("system||ntp")
+        .write_stdin("set system ntp server 192.0.2.1\nset interfaces ge-0/0/0 disable\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("set system ntp server 192.0.2.1"))
+        .stdout(predicate::str::contains("interfaces ge-0/0/0").not());
 }
 
 #[test]
@@ -93,4 +140,40 @@ fn diff_command_reports_changes_only_within_the_selected_slice() {
     .stdout(predicate::str::contains("-set system ntp server 192.0.2.1"))
     .stdout(predicate::str::contains("+set system ntp server 192.0.2.2"))
     .stdout(predicate::str::contains("interfaces ge-0/0/0").not());
+}
+
+#[test]
+fn diff_command_emits_no_output_when_selected_slice_matches() {
+    let temp_dir = TempDir::new().unwrap();
+    let source_path = write_config(
+        temp_dir.path(),
+        "source.conf",
+        concat!(
+            "set system ntp server 192.0.2.1\n",
+            "set interfaces ge-0/0/0 description old\n",
+        ),
+    );
+    let target_path = write_config(
+        temp_dir.path(),
+        "target.conf",
+        concat!(
+            "set system ntp server 192.0.2.1\n",
+            "set interfaces ge-0/0/0 description new\n",
+        ),
+    );
+
+    let mut cmd = Command::cargo_bin("config-slicer").unwrap();
+
+    cmd.args([
+        "diff",
+        "--match",
+        "system||ntp",
+        "--source",
+        &source_path,
+        "--target",
+        &target_path,
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::is_empty());
 }

--- a/crates/config-slicer/tests/cli.rs
+++ b/crates/config-slicer/tests/cli.rs
@@ -1,16 +1,96 @@
-use assert_cmd::prelude::*;
-use std::process::Command;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
 
-// Arrange-Act-Assert: run the binary with and without verbose to exercise main
-#[test]
-fn runs_without_args() {
-    let mut cmd = Command::cargo_bin("config-slicer").unwrap();
-    cmd.assert().success();
+fn write_config(root: &Path, file_name: &str, contents: &str) -> String {
+    let path = root.join(file_name);
+    fs::write(&path, contents).unwrap();
+    path.to_string_lossy().into_owned()
 }
 
 #[test]
-fn runs_with_verbose() {
+fn help_lists_parse_slice_and_diff_workflows() {
     let mut cmd = Command::cargo_bin("config-slicer").unwrap();
-    cmd.arg("--verbose");
-    cmd.assert().success();
+
+    cmd.arg("--help").assert().success().stdout(
+        predicate::str::contains("parse")
+            .and(predicate::str::contains("slice"))
+            .and(predicate::str::contains("diff")),
+    );
+}
+
+#[test]
+fn parse_command_supports_json_output() {
+    let mut cmd = Command::cargo_bin("config-slicer").unwrap();
+
+    cmd.args(["parse", "--match", "system||ntp", "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"expression\":\"system||ntp\""))
+        .stdout(predicate::str::contains("\"levels\":[\"system\",\"ntp\"]"));
+}
+
+#[test]
+fn slice_command_extracts_only_matching_lines() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = write_config(
+        temp_dir.path(),
+        "running.conf",
+        concat!(
+            "set system ntp server 192.0.2.1\n",
+            "set system ntp source-address 192.0.2.10\n",
+            "set interfaces ge-0/0/0 disable\n",
+        ),
+    );
+
+    let mut cmd = Command::cargo_bin("config-slicer").unwrap();
+
+    cmd.args(["slice", "--match", "system||ntp", &config_path])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("set system ntp server 192.0.2.1"))
+        .stdout(predicate::str::contains(
+            "set system ntp source-address 192.0.2.10",
+        ))
+        .stdout(predicate::str::contains("set interfaces ge-0/0/0 disable").not());
+}
+
+#[test]
+fn diff_command_reports_changes_only_within_the_selected_slice() {
+    let temp_dir = TempDir::new().unwrap();
+    let source_path = write_config(
+        temp_dir.path(),
+        "source.conf",
+        concat!(
+            "set system ntp server 192.0.2.1\n",
+            "set interfaces ge-0/0/0 description old\n",
+        ),
+    );
+    let target_path = write_config(
+        temp_dir.path(),
+        "target.conf",
+        concat!(
+            "set system ntp server 192.0.2.2\n",
+            "set interfaces ge-0/0/0 description new\n",
+        ),
+    );
+
+    let mut cmd = Command::cargo_bin("config-slicer").unwrap();
+
+    cmd.args([
+        "diff",
+        "--match",
+        "system||ntp",
+        "--source",
+        &source_path,
+        "--target",
+        &target_path,
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("-set system ntp server 192.0.2.1"))
+    .stdout(predicate::str::contains("+set system ntp server 192.0.2.2"))
+    .stdout(predicate::str::contains("interfaces ge-0/0/0").not());
 }

--- a/crates/config-slicer/tests/library.rs
+++ b/crates/config-slicer/tests/library.rs
@@ -1,6 +1,26 @@
 use config_slicer::{Vendor, diff_text, parse_match, slice_text};
 
 #[test]
+fn parse_match_rejects_empty_expression() {
+    let error = parse_match("").unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "invalid match expression: match expression cannot be empty"
+    );
+}
+
+#[test]
+fn parse_match_rejects_empty_levels() {
+    let error = parse_match("system||||ntp").unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "invalid match expression: match expression cannot contain empty levels"
+    );
+}
+
+#[test]
 fn slice_text_filters_flat_config_by_match_expression() {
     let spec = parse_match("system||ntp").unwrap();
     let config = concat!(
@@ -16,6 +36,29 @@ fn slice_text_filters_flat_config_by_match_expression() {
         vec![
             "set system ntp server 192.0.2.1".to_string(),
             "set system ntp source-address 192.0.2.10".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn slice_text_autodetects_vendor_when_requested() {
+    let spec = parse_match("system||services").unwrap();
+    let config = concat!(
+        "system {\n",
+        "    services {\n",
+        "        ssh;\n",
+        "    }\n",
+        "}\n",
+    );
+
+    let lines = slice_text(config, &spec, Vendor::Autodetect);
+
+    assert_eq!(
+        lines,
+        vec![
+            "    services {".to_string(),
+            "        ssh;".to_string(),
+            "    }".to_string(),
         ]
     );
 }
@@ -61,4 +104,21 @@ fn diff_text_ignores_unmatched_lines() {
     assert!(diff.contains("-set system ntp server 192.0.2.1"));
     assert!(diff.contains("+set system ntp server 192.0.2.2"));
     assert!(!diff.contains("interfaces ge-0/0/0"));
+}
+
+#[test]
+fn diff_text_returns_empty_string_when_slices_match() {
+    let spec = parse_match("system||ntp").unwrap();
+    let source = concat!(
+        "set system ntp server 192.0.2.1\n",
+        "set interfaces ge-0/0/0 description old\n",
+    );
+    let target = concat!(
+        "set system ntp server 192.0.2.1\n",
+        "set interfaces ge-0/0/0 description new\n",
+    );
+
+    let diff = diff_text(source, target, &spec, Vendor::Flat);
+
+    assert!(diff.is_empty());
 }

--- a/crates/config-slicer/tests/library.rs
+++ b/crates/config-slicer/tests/library.rs
@@ -1,0 +1,64 @@
+use config_slicer::{Vendor, diff_text, parse_match, slice_text};
+
+#[test]
+fn slice_text_filters_flat_config_by_match_expression() {
+    let spec = parse_match("system||ntp").unwrap();
+    let config = concat!(
+        "set system ntp server 192.0.2.1\n",
+        "set system ntp source-address 192.0.2.10\n",
+        "set interfaces ge-0/0/0 disable\n",
+    );
+
+    let lines = slice_text(config, &spec, Vendor::Flat);
+
+    assert_eq!(
+        lines,
+        vec![
+            "set system ntp server 192.0.2.1".to_string(),
+            "set system ntp source-address 192.0.2.10".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn slice_text_keeps_matching_junos_block() {
+    let spec = parse_match("system||services").unwrap();
+    let config = concat!(
+        "system {\n",
+        "    services {\n",
+        "        ssh;\n",
+        "    }\n",
+        "    host-name edge-1;\n",
+        "}\n",
+    );
+
+    let lines = slice_text(config, &spec, Vendor::Junos);
+
+    assert_eq!(
+        lines,
+        vec![
+            "    services {".to_string(),
+            "        ssh;".to_string(),
+            "    }".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn diff_text_ignores_unmatched_lines() {
+    let spec = parse_match("system||ntp").unwrap();
+    let source = concat!(
+        "set system ntp server 192.0.2.1\n",
+        "set interfaces ge-0/0/0 description old\n",
+    );
+    let target = concat!(
+        "set system ntp server 192.0.2.2\n",
+        "set interfaces ge-0/0/0 description new\n",
+    );
+
+    let diff = diff_text(source, target, &spec, Vendor::Flat);
+
+    assert!(diff.contains("-set system ntp server 192.0.2.1"));
+    assert!(diff.contains("+set system ntp server 192.0.2.2"));
+    assert!(!diff.contains("interfaces ge-0/0/0"));
+}


### PR DESCRIPTION
## Summary
- replace the placeholder `config-slicer` warning path with real `parse`, `slice`, and `diff` workflows
- add reusable match parsing, flat/Junos slicing, scoped unified diff output, and tests for both CLI and library behavior
- document the implemented CLI in `crates/config-slicer/README.md` and update `STATUS.md` to stop describing the crate as a stub

## Testing
- `CARGO_TARGET_DIR=/dev/shm/unet-bed-35-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' TMPDIR=/dev/shm mise run test -- -p config-slicer`
- `CARGO_TARGET_DIR=/dev/shm/unet-bed-35-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' TMPDIR=/dev/shm mise run lint`
- `mise run check-large-files`
