### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-minor-days: 7
+      semver-major-days: 30
     groups:
       all-version-updates:
         patterns:
@@ -17,6 +21,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       all-version-updates:
         patterns:


### PR DESCRIPTION
## Summary
- pin all GitHub Actions references to full commit SHAs
- add a `zizmor` workflow and Dependabot cooldowns
- isolate the write-scoped release step so artifact builds run read-only

## Testing
- parsed changed workflow and Dependabot YAML with `python3` + `yaml.safe_load`
