### PR TITLE
fix(deps): support reqwest 0.13 in unet-cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ sea-orm-migration = "1"
 axum = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", features = ["json", "rustls-tls"] }
 
 # CLI parsing
 clap = { version = "4.0", features = ["derive", "color", "suggestions"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ sea-orm-migration = "1"
 axum = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
-reqwest = { version = "0.13", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", features = ["json", "query"] }
 
 # CLI parsing
 clap = { version = "4.0", features = ["derive", "color", "suggestions"] }


### PR DESCRIPTION
Supersedes #97.

This keeps the `reqwest` 0.13 bump but updates the feature set for the new release:
- drop the removed `rustls-tls` feature
- enable `query`, which now gates `RequestBuilder::query()` in reqwest 0.13

Local verification:
- `cargo check -p unet-cli --message-format=short`
- `cargo check --workspace`
- `cargo doc --workspace --no-deps --document-private-items`
- `cargo nextest run --profile ci`

Notes:
- `cargo clippy --workspace --all-targets -- -D warnings` still hits pre-existing unrelated pedantic failures in `crates/config-slicer/tests/check_large_files_script.rs`, so I left that out of scope for this dependency fix.